### PR TITLE
Add copy-to-clipboard button for chart PNGs

### DIFF
--- a/web/src/components/charts/ChartDownloadWrapper.tsx
+++ b/web/src/components/charts/ChartDownloadWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRef, useCallback, ReactNode } from 'react';
-import { downloadChartAsPng, QuadrantLegendItem } from '@/lib/chartExport';
+import { useRef, useCallback, useState, ReactNode } from 'react';
+import { downloadChartAsPng, copyChartAsPng, QuadrantLegendItem } from '@/lib/chartExport';
 
 interface Props {
   children: ReactNode;
@@ -11,28 +11,62 @@ interface Props {
 
 export function ChartDownloadWrapper({ children, title, quadrantLegend }: Props) {
   const chartRef = useRef<HTMLDivElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const getFilterLabel = useCallback(() => {
+    if (!chartRef.current) return undefined;
+    const activeFilterEl = chartRef.current.querySelector('[data-active-filter]');
+    return activeFilterEl?.getAttribute('data-active-filter') || undefined;
+  }, []);
 
   const handleDownload = useCallback(() => {
     if (!chartRef.current) return;
-    // Read active week filter from data attribute if present
-    const activeFilterEl = chartRef.current.querySelector('[data-active-filter]');
-    const filterLabel = activeFilterEl?.getAttribute('data-active-filter') || undefined;
-    downloadChartAsPng(chartRef.current, title, quadrantLegend, filterLabel);
-  }, [title, quadrantLegend]);
+    downloadChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel());
+  }, [title, quadrantLegend, getFilterLabel]);
+
+  const handleCopy = useCallback(async () => {
+    if (!chartRef.current) return;
+    const ok = await copyChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel());
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  }, [title, quadrantLegend, getFilterLabel]);
+
+  const btnClass = "p-1 rounded hover:bg-[var(--border)] text-[var(--muted)] hover:text-[var(--foreground)] transition-colors z-10 opacity-50 hover:opacity-100";
 
   return (
     <div className="relative h-full">
-      <button
-        onClick={handleDownload}
-        className="absolute top-[5px] right-[5px] p-1 rounded hover:bg-[var(--border)] text-[var(--muted)] hover:text-[var(--foreground)] transition-colors z-10 opacity-50 hover:opacity-100"
-        title="Download as PNG"
-        aria-label="Download chart as PNG"
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M8 2v8M5 7l3 3 3-3" />
-          <path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2" />
-        </svg>
-      </button>
+      <div className="absolute top-[5px] right-[5px] flex gap-0.5 z-10">
+        <button
+          onClick={handleCopy}
+          className={btnClass}
+          title="Copy as PNG"
+          aria-label="Copy chart as PNG"
+        >
+          {copied ? (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 8.5l3 3 7-7" />
+            </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="5" y="5" width="8" height="8" rx="1" />
+              <path d="M3 11V3a1 1 0 011-1h8" />
+            </svg>
+          )}
+        </button>
+        <button
+          onClick={handleDownload}
+          className={btnClass}
+          title="Download as PNG"
+          aria-label="Download chart as PNG"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M8 2v8M5 7l3 3 3-3" />
+            <path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2" />
+          </svg>
+        </button>
+      </div>
       <div ref={chartRef} className="h-full">
         {children}
       </div>

--- a/web/src/components/charts/ChartWithTable.tsx
+++ b/web/src/components/charts/ChartWithTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo, useRef } from 'react';
-import { downloadChartAsPng, QuadrantLegendItem } from '@/lib/chartExport';
+import { downloadChartAsPng, copyChartAsPng, QuadrantLegendItem } from '@/lib/chartExport';
 import { ChartRenderer } from './ChartRenderer';
 import { ChartDataTable } from './ChartDataTable';
 import { ChartData, ScatterPlotData } from '@/types/chart';
@@ -159,11 +159,43 @@ function QuadrantLegend({
 
 const DOWNLOADABLE_TYPES = ['SCATTER_PLOT', 'LINE_CHART', 'BAR_CHART', 'BAR_GRAPH'];
 
+const chartBtnClass = "p-1 rounded hover:bg-[var(--border)] text-[var(--muted)] hover:text-[var(--foreground)] transition-colors opacity-50 hover:opacity-100";
+
+function CopyButton({ onClick }: { onClick: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = useCallback(() => {
+    onClick();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [onClick]);
+
+  return (
+    <button
+      onClick={handleClick}
+      className={chartBtnClass}
+      title="Copy as PNG"
+      aria-label="Copy chart as PNG"
+    >
+      {copied ? (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 8.5l3 3 7-7" />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="5" y="5" width="8" height="8" rx="1" />
+          <path d="M3 11V3a1 1 0 011-1h8" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
 function DownloadButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       onClick={onClick}
-      className="absolute top-[5px] right-[5px] p-1 rounded hover:bg-[var(--border)] text-[var(--muted)] hover:text-[var(--foreground)] transition-colors z-10 opacity-50 hover:opacity-100"
+      className={chartBtnClass}
       title="Download as PNG"
       aria-label="Download chart as PNG"
     >
@@ -204,6 +236,12 @@ export function ChartWithTable({ data, title, subtitle, source, lastUpdated }: P
   const handleDownload = useCallback(() => {
     if (chartRef.current) {
       downloadChartAsPng(chartRef.current, title, quadrantLegendItems);
+    }
+  }, [title, quadrantLegendItems]);
+
+  const handleCopy = useCallback(() => {
+    if (chartRef.current) {
+      copyChartAsPng(chartRef.current, title, quadrantLegendItems);
     }
   }, [title, quadrantLegendItems]);
 
@@ -258,7 +296,12 @@ export function ChartWithTable({ data, title, subtitle, source, lastUpdated }: P
       {/* Chart + About — left 50% */}
       <div className="lg:w-1/2 lg:overflow-y-auto">
         <section className="relative border border-[var(--border)] bg-[var(--card)] rounded-none md:rounded p-2 md:p-4">
-          {showDownload && <DownloadButton onClick={handleDownload} />}
+          {showDownload && (
+            <div className="absolute top-[5px] right-[5px] flex gap-0.5 z-10">
+              <CopyButton onClick={handleCopy} />
+              <DownloadButton onClick={handleDownload} />
+            </div>
+          )}
           <div ref={chartRef} className="h-[400px] md:h-[500px]">
             <ChartRenderer
               data={data}

--- a/web/src/lib/chartExport.ts
+++ b/web/src/lib/chartExport.ts
@@ -23,17 +23,17 @@ export interface QuadrantLegendItem {
   count?: number;
 }
 
-export async function downloadChartAsPng(
+async function renderChartToCanvas(
   chartContainer: HTMLElement,
   title?: string,
   quadrantLegend?: QuadrantLegendItem[],
   filterLabel?: string,
-): Promise<void> {
+): Promise<HTMLCanvasElement | null> {
   const svgEl = chartContainer.querySelector('svg');
-  if (!svgEl) return;
+  if (!svgEl) return null;
 
   const rect = svgEl.getBoundingClientRect();
-  if (!rect.width || !rect.height) return;
+  if (!rect.width || !rect.height) return null;
 
   // Clone so we can modify attributes without affecting the live DOM
   const clonedSvg = svgEl.cloneNode(true) as SVGSVGElement;
@@ -72,7 +72,7 @@ export async function downloadChartAsPng(
   canvas.style.width = `${canvasWidth}px`;
   canvas.style.height = `${canvasHeight}px`;
   const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+  if (!ctx) return null;
 
   ctx.scale(DPI_SCALE, DPI_SCALE);
 
@@ -99,7 +99,7 @@ export async function downloadChartAsPng(
   const url = URL.createObjectURL(blob);
   const img = new Image();
 
-  return new Promise<void>((resolve) => {
+  return new Promise<HTMLCanvasElement | null>((resolve) => {
     img.onload = () => {
       ctx.drawImage(img, padding, titleHeight + filterHeight + padding, exportWidth, exportHeight);
       URL.revokeObjectURL(url);
@@ -123,20 +123,53 @@ export async function downloadChartAsPng(
         }
       }
 
-      const filename = title
-        ? title.replace(/[^a-zA-Z0-9\-_ ]/g, '').replace(/\s+/g, '-') + '.png'
-        : 'chart.png';
-
-      const link = document.createElement('a');
-      link.download = filename;
-      link.href = canvas.toDataURL('image/png');
-      link.click();
-      resolve();
+      resolve(canvas);
     };
     img.onerror = () => {
       URL.revokeObjectURL(url);
-      resolve();
+      resolve(null);
     };
     img.src = url;
+  });
+}
+
+export async function downloadChartAsPng(
+  chartContainer: HTMLElement,
+  title?: string,
+  quadrantLegend?: QuadrantLegendItem[],
+  filterLabel?: string,
+): Promise<void> {
+  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel);
+  if (!canvas) return;
+
+  const filename = title
+    ? title.replace(/[^a-zA-Z0-9\-_ ]/g, '').replace(/\s+/g, '-') + '.png'
+    : 'chart.png';
+
+  const link = document.createElement('a');
+  link.download = filename;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}
+
+export async function copyChartAsPng(
+  chartContainer: HTMLElement,
+  title?: string,
+  quadrantLegend?: QuadrantLegendItem[],
+  filterLabel?: string,
+): Promise<boolean> {
+  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel);
+  if (!canvas) return false;
+
+  return new Promise<boolean>((resolve) => {
+    canvas.toBlob(async (blob) => {
+      if (!blob) { resolve(false); return; }
+      try {
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+        resolve(true);
+      } catch {
+        resolve(false);
+      }
+    }, 'image/png');
   });
 }


### PR DESCRIPTION
## Summary
- Adds a clipboard icon button next to the existing download button on all chart visualizations
- Clicking it renders the chart to a PNG and copies it to the user's clipboard via the Clipboard API
- Refactors `chartExport.ts` to share canvas rendering logic between download and copy functions

## Test plan
- [x] Click copy button on scatter plot, line chart, bar chart — verify PNG pastes correctly
- [x] Verify checkmark feedback appears for ~1.5s after copying
- [x] Verify download button still works as before
- [x] Test on matchup detail pages (NBA/NHL) which use `ChartDownloadWrapper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)