### PR TITLE
Add pinned teams feature

### DIFF
--- a/web/content/blog/2026-roadmap.mdx
+++ b/web/content/blog/2026-roadmap.mdx
@@ -6,7 +6,7 @@ description: "2026 feature roadmap for fastbreak"
 author: "Joe Badaczewski"
 authorUrl: "https://joebad.com"
 ---
-<GoalProgress inProgress={1} total={16} completed={11} />
+<GoalProgress inProgress={1} total={16} completed={13} />
 
 ## 1. College basketball features
 
@@ -24,10 +24,10 @@ authorUrl: "https://joebad.com"
 
 ## 3. Web project parity: sharing, filtering, matchup worksheets, pinning teams and storing in local storage
 
-- ⏳ Sharing visualizations
+- ✅ Copying and downloading visualizations [[tweet]](https://x.com/joe307bad/status/2041596471020028293?s=20)
 - ✅ Filtering and sorting tables and visualizations [[link]](/nba/chart/nba__team_efficiency)
 - ✅ Matchup worksheets for NBA and NHL [[link]](/nba/matchups/) [[link]](/nhl/matchups/) [[tweet]](https://x.com/joe307bad/status/2039688950843887927?s=20)
-- Pinning teams
+- ✅ Pinning teams [[link]](/settings/pinned-teams)
 
 ## 4. Daily summaries and insights based on Google search results and backed by fastbreak charts
 

--- a/web/src/app/nba/matchups/[gameId]/page.tsx
+++ b/web/src/app/nba/matchups/[gameId]/page.tsx
@@ -380,7 +380,7 @@ export default async function NBAMatchupPage({ params }: Props) {
           {/* Charts - square-ish dimensions */}
           <div className="flex flex-col gap-2 h-[700px] lg:h-[calc(100vh-80px)] order-2 lg:order-1">
             <div className="flex-1">
-              <ChartDownloadWrapper title="Cumulative Net Rating by Week">
+              <ChartDownloadWrapper title="Cumulative Net Rating by Week" source={matchupData.source}>
                 <CumNetRatingChart
                   homeTeamStats={game.homeTeam.stats}
                   awayTeamStats={game.awayTeam.stats}
@@ -392,7 +392,7 @@ export default async function NBAMatchupPage({ params }: Props) {
               </ChartDownloadWrapper>
             </div>
             <div className="flex-1">
-              <ChartDownloadWrapper title="Weekly Offensive vs Defensive Rating" quadrantLegend={
+              <ChartDownloadWrapper title="Weekly Offensive vs Defensive Rating" source={matchupData.source} quadrantLegend={
                 matchupData.scatterPlotQuadrants ? [
                   matchupData.scatterPlotQuadrants.topRight,
                   matchupData.scatterPlotQuadrants.topLeft,

--- a/web/src/app/nhl/matchups/[gameId]/page.tsx
+++ b/web/src/app/nhl/matchups/[gameId]/page.tsx
@@ -338,7 +338,7 @@ export default async function NHLMatchupPage({ params }: Props) {
           {/* Charts - square-ish dimensions */}
           <div className="flex flex-col gap-2 h-[700px] lg:h-[calc(100vh-80px)] order-2 lg:order-1">
             <div className="flex-1">
-              <ChartDownloadWrapper title="Cumulative xGF% by Week">
+              <ChartDownloadWrapper title="Cumulative xGF% by Week" source={matchupData.source}>
                 <CumXgChart
                   homeTeamStats={game.homeTeam.stats}
                   awayTeamStats={game.awayTeam.stats}
@@ -350,7 +350,7 @@ export default async function NHLMatchupPage({ params }: Props) {
               </ChartDownloadWrapper>
             </div>
             <div className="flex-1">
-              <ChartDownloadWrapper title="xG For vs Points Pace" quadrantLegend={[
+              <ChartDownloadWrapper title="xG For vs Points Pace" source={matchupData.source} quadrantLegend={[
                 { label: 'Elite', color: '#22c55e' },
                 { label: 'Lucky', color: '#f59e0b' },
                 { label: 'Unlucky', color: '#3b82f6' },

--- a/web/src/app/settings/pinned-teams/page.tsx
+++ b/web/src/app/settings/pinned-teams/page.tsx
@@ -1,16 +1,13 @@
 import type { Metadata } from 'next';
+import { fetchAllTeamRosters } from '@/lib/teams';
+import { PinnedTeamsManager } from '@/components/ui/PinnedTeamsManager';
 
 export const metadata: Metadata = {
   title: 'Pinned Teams',
 };
 
-export default function PinnedTeamsPage() {
-  return (
-    <div>
-      <h2 className="text-lg font-bold mb-4">Pinned Teams</h2>
-      <p className="text-sm text-[var(--muted)]">
-        Work in progress
-      </p>
-    </div>
-  );
+export default async function PinnedTeamsPage() {
+  const rosters = await fetchAllTeamRosters();
+
+  return <PinnedTeamsManager rosters={rosters} />;
 }

--- a/web/src/components/charts/ChartDataTable.tsx
+++ b/web/src/components/charts/ChartDataTable.tsx
@@ -11,6 +11,7 @@ import {
   SortingState,
 } from '@tanstack/react-table';
 import { ChartData, ScatterPlotData } from '@/types/chart';
+import { usePinnedTeams } from '@/lib/usePinnedTeams';
 
 type QuadrantKey = 'topRight' | 'topLeft' | 'bottomLeft' | 'bottomRight';
 
@@ -192,6 +193,9 @@ interface ChartDataTableProps {
 export function ChartDataTable({ data, onHighlight, selectedLabel, getItemColor, onSelect, quadrantFilter }: ChartDataTableProps) {
   const { rows, columnKeys } = useMemo(() => buildTableData(data), [data]);
   const { conferences, divisions } = useMemo(() => extractFilterOptions(data), [data]);
+  const { pinnedTeams, getPinnedForSport } = usePinnedTeams();
+  // '' = no pinned filter, 'all' = all pinned, or a specific teamCode
+  const [pinnedFilter, setPinnedFilter] = useState<string>('');
 
   // Determine default sort column: prefer 'sum', then 'value'
   const defaultSortColumn = useMemo(() => {
@@ -242,25 +246,55 @@ export function ChartDataTable({ data, onHighlight, selectedLabel, getItemColor,
   );
 
   // Filter rows based on conference and division
+  const sportPinnedTeams = useMemo(() => {
+    if (!data.sport) return [];
+    return getPinnedForSport(data.sport);
+  }, [data.sport, getPinnedForSport]);
+
+  // Build the set of pinned team codes to match against
+  const pinnedFilterCodes = useMemo(() => {
+    if (!pinnedFilter) return null;
+    if (pinnedFilter === 'all') {
+      return new Set(sportPinnedTeams.map(t => t.teamCode.toUpperCase()));
+    }
+    return new Set([pinnedFilter.toUpperCase()]);
+  }, [pinnedFilter, sportPinnedTeams]);
+
   const filteredRows = useMemo(() => {
     return rows.filter(row => {
+      const teamVal = (row.team as string | undefined)?.toUpperCase();
+      const labelVal = row.label.toUpperCase();
+
+      // Check if row matches pinned teams filter
+      const matchesPinned = pinnedFilterCodes
+        ? pinnedFilterCodes.has(teamVal ?? '') || pinnedFilterCodes.has(labelVal)
+        : false;
+
+      // Standard filters (conference, division, quadrant)
+      let passesStandardFilters = true;
       if (conferenceFilter) {
         const confVal = row.conf as string | undefined;
-        if (!confVal) return false;
-        const parsed = parseConfValue(confVal);
-        if (parsed.conf !== conferenceFilter && confVal !== conferenceFilter) return false;
+        if (!confVal) { passesStandardFilters = false; }
+        else {
+          const parsed = parseConfValue(confVal);
+          if (parsed.conf !== conferenceFilter && confVal !== conferenceFilter) passesStandardFilters = false;
+        }
       }
-      if (divisionFilter) {
-        if (row.division !== divisionFilter) return false;
+      if (passesStandardFilters && divisionFilter) {
+        if (row.division !== divisionFilter) passesStandardFilters = false;
       }
-      // Filter by quadrant for scatter plots
-      if (quadrantFilter && data.visualizationType === 'SCATTER_PLOT') {
+      if (passesStandardFilters && quadrantFilter && data.visualizationType === 'SCATTER_PLOT') {
         const pointQuadrant = getPointQuadrant(data, row.label);
-        if (pointQuadrant !== quadrantFilter) return false;
+        if (pointQuadrant !== quadrantFilter) passesStandardFilters = false;
       }
-      return true;
+
+      // Pinned filter is additive: row shows if it matches pinned OR passes standard filters
+      if (pinnedFilterCodes) {
+        return matchesPinned || passesStandardFilters;
+      }
+      return passesStandardFilters;
     });
-  }, [rows, conferenceFilter, divisionFilter, quadrantFilter, data]);
+  }, [rows, conferenceFilter, divisionFilter, quadrantFilter, data, pinnedFilterCodes]);
 
   const table = useReactTable({
     data: filteredRows,
@@ -279,7 +313,7 @@ export function ChartDataTable({ data, onHighlight, selectedLabel, getItemColor,
       const visibleLabels = table.getFilteredRowModel().rows.map(row => row.original.label);
       onHighlight(visibleLabels);
     }
-  }, [conferenceFilter, divisionFilter, globalFilter, table, onHighlight]);
+  }, [conferenceFilter, divisionFilter, globalFilter, pinnedFilter, table, onHighlight]);
 
   if (rows.length === 0) return null;
 
@@ -288,6 +322,19 @@ export function ChartDataTable({ data, onHighlight, selectedLabel, getItemColor,
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex flex-wrap items-center gap-2 mb-3 shrink-0">
+        {sportPinnedTeams.length > 0 && (
+          <select
+            value={pinnedFilter}
+            onChange={e => setPinnedFilter(e.target.value)}
+            className="px-2 py-1.5 text-sm border border-[var(--border)] rounded bg-[var(--background)] text-[var(--foreground)]"
+          >
+            <option value="">All Teams</option>
+            <option value="all">All Pinned</option>
+            {sportPinnedTeams.map(t => (
+              <option key={t.teamCode} value={t.teamCode}>{t.teamCode} - {t.teamLabel}</option>
+            ))}
+          </select>
+        )}
         {conferences.length > 0 && (
           <select
             value={conferenceFilter}

--- a/web/src/components/charts/ChartDownloadWrapper.tsx
+++ b/web/src/components/charts/ChartDownloadWrapper.tsx
@@ -7,9 +7,10 @@ interface Props {
   children: ReactNode;
   title?: string;
   quadrantLegend?: QuadrantLegendItem[];
+  source?: string;
 }
 
-export function ChartDownloadWrapper({ children, title, quadrantLegend }: Props) {
+export function ChartDownloadWrapper({ children, title, quadrantLegend, source }: Props) {
   const chartRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
 
@@ -21,17 +22,17 @@ export function ChartDownloadWrapper({ children, title, quadrantLegend }: Props)
 
   const handleDownload = useCallback(() => {
     if (!chartRef.current) return;
-    downloadChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel());
-  }, [title, quadrantLegend, getFilterLabel]);
+    downloadChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel(), source);
+  }, [title, quadrantLegend, getFilterLabel, source]);
 
   const handleCopy = useCallback(async () => {
     if (!chartRef.current) return;
-    const ok = await copyChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel());
+    const ok = await copyChartAsPng(chartRef.current, title, quadrantLegend, getFilterLabel(), source);
     if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     }
-  }, [title, quadrantLegend, getFilterLabel]);
+  }, [title, quadrantLegend, getFilterLabel, source]);
 
   const btnClass = "p-1 rounded hover:bg-[var(--border)] text-[var(--muted)] hover:text-[var(--foreground)] transition-colors z-10 opacity-50 hover:opacity-100";
 

--- a/web/src/components/charts/ChartWithTable.tsx
+++ b/web/src/components/charts/ChartWithTable.tsx
@@ -235,15 +235,15 @@ export function ChartWithTable({ data, title, subtitle, source, lastUpdated }: P
 
   const handleDownload = useCallback(() => {
     if (chartRef.current) {
-      downloadChartAsPng(chartRef.current, title, quadrantLegendItems);
+      downloadChartAsPng(chartRef.current, title, quadrantLegendItems, undefined, source);
     }
-  }, [title, quadrantLegendItems]);
+  }, [title, quadrantLegendItems, source]);
 
   const handleCopy = useCallback(() => {
     if (chartRef.current) {
-      copyChartAsPng(chartRef.current, title, quadrantLegendItems);
+      copyChartAsPng(chartRef.current, title, quadrantLegendItems, undefined, source);
     }
-  }, [title, quadrantLegendItems]);
+  }, [title, quadrantLegendItems, source]);
 
   // Compute effective highlighted labels based on table filters and quadrant filter
   const effectiveHighlightedLabels = useMemo(() => {

--- a/web/src/components/charts/MatchupsWithNav.tsx
+++ b/web/src/components/charts/MatchupsWithNav.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { MatchupData, NBAMatchupData, NBAMatchupDataPoint, NHLMatchupData, NHLMatchupDataPoint, MatchupV2Data, MatchupV2DataPoint } from '@/types/chart';
 import { MatchupNav, getFilteredMatchups } from '@/components/ui/MatchupNav';
+import { usePinnedTeams } from '@/lib/usePinnedTeams';
 
 type AnyMatchupData = MatchupData | NBAMatchupData | NHLMatchupData | MatchupV2Data;
 
@@ -36,12 +37,12 @@ function getTodayKey(): string {
 }
 
 // NBA Matchup Card
-function NBAMatchupCard({ matchup, expanded }: { matchup: NBAMatchupDataPoint; expanded?: boolean }) {
+function NBAMatchupCard({ matchup, expanded, pinned }: { matchup: NBAMatchupDataPoint; expanded?: boolean; pinned?: boolean }) {
   const { date, time } = formatGameTime(matchup.gameDate);
   const isCompleted = matchup.gameCompleted;
 
   return (
-    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''}`}>
+    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''} ${pinned ? 'border-l-2 border-l-blue-500' : ''}`}>
       {/* Header: Date/Time and Status */}
       <div className="flex justify-between items-center text-xs text-[var(--muted)] mb-2">
         <span>{date}</span>
@@ -109,12 +110,12 @@ function NBAMatchupCard({ matchup, expanded }: { matchup: NBAMatchupDataPoint; e
 }
 
 // NHL Matchup Card
-function NHLMatchupCard({ matchup, expanded }: { matchup: NHLMatchupDataPoint; expanded?: boolean }) {
+function NHLMatchupCard({ matchup, expanded, pinned }: { matchup: NHLMatchupDataPoint; expanded?: boolean; pinned?: boolean }) {
   const { date, time } = formatGameTime(matchup.gameDate);
   const isCompleted = matchup.gameCompleted;
 
   return (
-    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''}`}>
+    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''} ${pinned ? 'border-l-2 border-l-blue-500' : ''}`}>
       {/* Header: Date/Time and Status */}
       <div className="flex justify-between items-center text-xs text-[var(--muted)] mb-2">
         <span>{date}</span>
@@ -182,13 +183,13 @@ function NHLMatchupCard({ matchup, expanded }: { matchup: NHLMatchupDataPoint; e
 }
 
 // NFL/V2 Matchup Card
-function NFLMatchupCard({ matchupKey, matchup, expanded }: { matchupKey: string; matchup: MatchupV2DataPoint; expanded?: boolean }) {
+function NFLMatchupCard({ matchupKey, matchup, expanded, pinned }: { matchupKey: string; matchup: MatchupV2DataPoint; expanded?: boolean; pinned?: boolean }) {
   const { date, time } = formatGameTime(matchup.game_datetime);
   const [awayCode, homeCode] = matchupKey.split('-').map(s => s.toUpperCase());
   const odds = matchup.odds;
 
   return (
-    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''}`}>
+    <div className={`border border-[var(--border)] rounded p-3 bg-[var(--card)] ${expanded ? 'ring-2 ring-[var(--foreground)]/20' : ''} ${pinned ? 'border-l-2 border-l-blue-500' : ''}`}>
       {/* Header: Date/Time */}
       <div className="flex justify-between items-center text-xs text-[var(--muted)] mb-2">
         <span>{date}</span>
@@ -243,6 +244,28 @@ export function MatchupsWithNav({ data }: Props) {
   // Default to today
   const [selectedDay, setSelectedDay] = useState<string | null>(getTodayKey());
   const [selectedMatchup, setSelectedMatchup] = useState<string | null>(null);
+  const { getPinnedForSport } = usePinnedTeams();
+
+  const sport = useMemo(() => {
+    if (data.visualizationType === 'NBA_MATCHUP') return 'nba';
+    if (data.visualizationType === 'NHL_MATCHUP') return 'nhl';
+    if (data.visualizationType === 'MATCHUP_V2') return 'nfl';
+    return data.sport?.toLowerCase() ?? '';
+  }, [data]);
+
+  const pinnedCodes = useMemo(() => {
+    const pinned = getPinnedForSport(sport);
+    return new Set(pinned.map(t => t.teamCode.toUpperCase()));
+  }, [sport, getPinnedForSport]);
+
+  const sortPinnedFirst = useCallback(<T,>(items: T[], getTeams: (item: T) => string[]): T[] => {
+    if (pinnedCodes.size === 0) return items;
+    return [...items].sort((a, b) => {
+      const aPinned = getTeams(a).some(code => pinnedCodes.has(code.toUpperCase())) ? 0 : 1;
+      const bPinned = getTeams(b).some(code => pinnedCodes.has(code.toUpperCase())) ? 0 : 1;
+      return aPinned - bPinned;
+    });
+  }, [pinnedCodes]);
 
   const { matchupIds, showAll } = useMemo(
     () => getFilteredMatchups(data, selectedDay, selectedMatchup),
@@ -260,17 +283,20 @@ export function MatchupsWithNav({ data }: Props) {
         ? games
         : games.filter(g => matchupIds.includes(g.gameId));
 
-      if (filteredGames.length === 0) {
+      const sortedGames = sortPinnedFirst(filteredGames, g => [g.awayTeam.abbreviation, g.homeTeam.abbreviation]);
+
+      if (sortedGames.length === 0) {
         return <p className="text-[var(--muted)] text-sm">No upcoming games</p>;
       }
 
       return (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {filteredGames.map(matchup => (
+          {sortedGames.map(matchup => (
             <NBAMatchupCard
               key={matchup.gameId}
               matchup={matchup}
               expanded={selectedMatchup === matchup.gameId}
+              pinned={[matchup.awayTeam.abbreviation, matchup.homeTeam.abbreviation].some(c => pinnedCodes.has(c.toUpperCase()))}
             />
           ))}
         </div>
@@ -286,17 +312,20 @@ export function MatchupsWithNav({ data }: Props) {
         ? games
         : games.filter(g => matchupIds.includes(g.gameId));
 
-      if (filteredGames.length === 0) {
+      const sortedGames = sortPinnedFirst(filteredGames, g => [g.awayTeam.abbreviation, g.homeTeam.abbreviation]);
+
+      if (sortedGames.length === 0) {
         return <p className="text-[var(--muted)] text-sm">No upcoming games</p>;
       }
 
       return (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {filteredGames.map(matchup => (
+          {sortedGames.map(matchup => (
             <NHLMatchupCard
               key={matchup.gameId}
               matchup={matchup}
               expanded={selectedMatchup === matchup.gameId}
+              pinned={[matchup.awayTeam.abbreviation, matchup.homeTeam.abbreviation].some(c => pinnedCodes.has(c.toUpperCase()))}
             />
           ))}
         </div>
@@ -313,18 +342,21 @@ export function MatchupsWithNav({ data }: Props) {
         ? matchupEntries
         : matchupEntries.filter(([key]) => matchupIds.includes(key));
 
-      if (filteredEntries.length === 0) {
+      const sortedEntries = sortPinnedFirst(filteredEntries, ([key]) => key.split('-').map(s => s.toUpperCase()));
+
+      if (sortedEntries.length === 0) {
         return <p className="text-[var(--muted)] text-sm">No upcoming games</p>;
       }
 
       return (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {filteredEntries.map(([key, matchup]) => (
+          {sortedEntries.map(([key, matchup]) => (
             <NFLMatchupCard
               key={key}
               matchupKey={key}
               matchup={matchup}
               expanded={selectedMatchup === key}
+              pinned={key.split('-').some(s => pinnedCodes.has(s.toUpperCase()))}
             />
           ))}
         </div>

--- a/web/src/components/ui/PinnedTeamsManager.tsx
+++ b/web/src/components/ui/PinnedTeamsManager.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { usePinnedTeams } from '@/lib/usePinnedTeams';
+import type { TeamRoster, TeamRosterEntry } from '@/types/pinnedTeams';
+
+interface Props {
+  rosters: TeamRoster[];
+}
+
+function extractTeamLabel(longLabel: string): string {
+  // longLabel is like "NFL - Philadelphia Eagles", extract the team name
+  const idx = longLabel.indexOf(' - ');
+  return idx >= 0 ? longLabel.slice(idx + 3) : longLabel;
+}
+
+export function PinnedTeamsManager({ rosters }: Props) {
+  const { pinnedTeams, mounted, pinTeam, unpinTeam, isPinned } = usePinnedTeams();
+  const [search, setSearch] = useState('');
+
+  const filteredRosters = useMemo(() => {
+    const query = search.toLowerCase().trim();
+    if (!query) return rosters.map(r => ({ ...r, teams: r.teams }));
+
+    return rosters
+      .map(roster => ({
+        ...roster,
+        teams: roster.teams.filter(t =>
+          t.code.toLowerCase().includes(query) ||
+          t.longLabel.toLowerCase().includes(query) ||
+          t.conference.toLowerCase().includes(query) ||
+          t.division.toLowerCase().includes(query)
+        ),
+      }))
+      .filter(r => r.teams.length > 0);
+  }, [rosters, search]);
+
+  const pinnedBySport = useMemo(() => {
+    const grouped: Record<string, typeof pinnedTeams> = {};
+    for (const t of pinnedTeams) {
+      const key = t.sport.toUpperCase();
+      if (!grouped[key]) grouped[key] = [];
+      grouped[key].push(t);
+    }
+    return grouped;
+  }, [pinnedTeams]);
+
+  const handleToggle = (roster: TeamRoster, team: TeamRosterEntry) => {
+    const sport = roster.sport.toLowerCase();
+    if (isPinned(sport, team.code)) {
+      unpinTeam(sport, team.code);
+    } else {
+      pinTeam(sport, team.code, extractTeamLabel(team.longLabel));
+    }
+  };
+
+  if (!mounted) {
+    return (
+      <div>
+        <h2 className="text-lg font-bold mb-4">Pinned Teams</h2>
+        <p className="text-sm text-[var(--muted)]">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">Pinned Teams</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_280px] gap-4">
+        {/* Panel 1 + 2: Search & Results */}
+        <div className="md:col-span-2 flex flex-col min-h-0">
+          {/* Search input */}
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search teams by name, code, conference, or division..."
+            className="w-full px-3 py-2 text-sm border border-[var(--border)] rounded bg-[var(--background)] text-[var(--foreground)] placeholder:text-[var(--muted)] mb-3"
+          />
+
+          {/* Results */}
+          <div className="overflow-y-auto max-h-[65vh] border border-[var(--border)] rounded">
+            {filteredRosters.length === 0 ? (
+              <p className="text-sm text-[var(--muted)] p-4">No teams match your search.</p>
+            ) : (
+              filteredRosters.map(roster => (
+                <div key={roster.sport}>
+                  {/* Sport header */}
+                  <div className="sticky top-0 z-10 px-3 py-2 text-xs font-bold uppercase tracking-wider text-[var(--muted)] bg-[var(--card)] border-b border-[var(--border)]">
+                    {roster.sport.toUpperCase()}
+                  </div>
+
+                  {/* Team rows */}
+                  {roster.teams.map(team => {
+                    const pinned = isPinned(roster.sport.toLowerCase(), team.code);
+                    return (
+                      <button
+                        key={`${roster.sport}-${team.code}`}
+                        onClick={() => handleToggle(roster, team)}
+                        className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left border-b border-[var(--border)] last:border-b-0 transition-colors hover:bg-[var(--card)] ${
+                          pinned ? 'bg-[var(--card)]' : ''
+                        }`}
+                      >
+                        {/* Pin indicator */}
+                        <span className={`shrink-0 w-5 h-5 flex items-center justify-center rounded border ${
+                          pinned
+                            ? 'bg-[var(--foreground)] text-[var(--background)] border-[var(--foreground)]'
+                            : 'border-[var(--border)]'
+                        }`}>
+                          {pinned && (
+                            <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
+                              <path d="M2 6l3 3 5-5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          )}
+                        </span>
+
+                        {/* Team info */}
+                        <span className="font-mono font-bold w-10">{team.code}</span>
+                        <span className="flex-1 truncate">{extractTeamLabel(team.longLabel)}</span>
+                        <span className="text-xs text-[var(--muted)] hidden sm:inline">{team.division}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Panel 3: Currently Pinned */}
+        <div className="flex flex-col min-h-0">
+          <div className="text-xs font-bold uppercase tracking-wider text-[var(--muted)] mb-2">
+            Pinned ({pinnedTeams.length})
+          </div>
+          <div className="overflow-y-auto max-h-[65vh] border border-[var(--border)] rounded bg-[var(--card)]">
+            {pinnedTeams.length === 0 ? (
+              <p className="text-sm text-[var(--muted)] p-4">
+                No pinned teams yet. Select teams from the list to pin them.
+              </p>
+            ) : (
+              Object.entries(pinnedBySport).map(([sport, teams]) => (
+                <div key={sport}>
+                  <div className="px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-[var(--muted)] bg-[var(--background)] border-b border-[var(--border)]">
+                    {sport}
+                  </div>
+                  {teams.map(t => (
+                    <div
+                      key={`${t.sport}-${t.teamCode}`}
+                      className="flex items-center justify-between px-3 py-2 text-sm border-b border-[var(--border)] last:border-b-0"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono font-bold">{t.teamCode}</span>
+                        <span className="truncate">{t.teamLabel}</span>
+                      </div>
+                      <button
+                        onClick={() => unpinTeam(t.sport, t.teamCode)}
+                        className="shrink-0 p-1 text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+                        aria-label={`Remove ${t.teamLabel}`}
+                      >
+                        <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/chartExport.ts
+++ b/web/src/lib/chartExport.ts
@@ -28,6 +28,7 @@ async function renderChartToCanvas(
   title?: string,
   quadrantLegend?: QuadrantLegendItem[],
   filterLabel?: string,
+  source?: string,
 ): Promise<HTMLCanvasElement | null> {
   const svgEl = chartContainer.querySelector('svg');
   if (!svgEl) return null;
@@ -62,9 +63,10 @@ async function renderChartToCanvas(
   const titleHeight = title ? 48 : 0;
   const legendHeight = quadrantLegend?.length ? 36 : 0;
   const filterHeight = filterLabel ? 28 : 0;
+  const footerHeight = 32;
   const padding = 16;
   const canvasWidth = exportWidth + padding * 2;
-  const canvasHeight = exportHeight + titleHeight + filterHeight + legendHeight + padding * 2;
+  const canvasHeight = exportHeight + titleHeight + filterHeight + legendHeight + footerHeight + padding * 2;
 
   const canvas = document.createElement('canvas');
   canvas.width = canvasWidth * DPI_SCALE;
@@ -123,6 +125,17 @@ async function renderChartToCanvas(
         }
       }
 
+      // Draw footer with source and site URL
+      const footerY = canvasHeight - padding;
+      ctx.font = '11px monospace';
+      ctx.fillStyle = vars['--muted'] || '#888888';
+      const sourceText = source ? `Source: ${source}` : '';
+      const siteText = 'fbrk.app';
+      if (sourceText) {
+        ctx.fillText(sourceText, padding, footerY);
+      }
+      ctx.fillText(siteText, canvasWidth - padding - ctx.measureText(siteText).width, footerY);
+
       resolve(canvas);
     };
     img.onerror = () => {
@@ -138,8 +151,9 @@ export async function downloadChartAsPng(
   title?: string,
   quadrantLegend?: QuadrantLegendItem[],
   filterLabel?: string,
+  source?: string,
 ): Promise<void> {
-  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel);
+  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel, source);
   if (!canvas) return;
 
   const filename = title
@@ -157,8 +171,9 @@ export async function copyChartAsPng(
   title?: string,
   quadrantLegend?: QuadrantLegendItem[],
   filterLabel?: string,
+  source?: string,
 ): Promise<boolean> {
-  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel);
+  const canvas = await renderChartToCanvas(chartContainer, title, quadrantLegend, filterLabel, source);
   if (!canvas) return false;
 
   return new Promise<boolean>((resolve) => {

--- a/web/src/lib/teams.ts
+++ b/web/src/lib/teams.ts
@@ -1,0 +1,22 @@
+import type { TeamRoster } from '@/types/pinnedTeams';
+
+const CLOUDFRONT_URL = 'https://d2jyizt5xogu23.cloudfront.net';
+const SPORTS = ['nfl', 'nba', 'nhl'] as const;
+
+function getTeamRosterUrl(sport: string): string {
+  const prefix = process.env.FASTBREAK_ENV === 'prod' ? '' : 'dev/';
+  return `${CLOUDFRONT_URL}/${prefix}teams/${sport}__teams.json`;
+}
+
+export async function fetchAllTeamRosters(): Promise<TeamRoster[]> {
+  const rosters = await Promise.all(
+    SPORTS.map(async (sport) => {
+      const res = await fetch(getTeamRosterUrl(sport));
+      if (!res.ok) {
+        throw new Error(`Failed to fetch ${sport} team roster: ${res.status}`);
+      }
+      return res.json() as Promise<TeamRoster>;
+    })
+  );
+  return rosters;
+}

--- a/web/src/lib/usePinnedTeams.ts
+++ b/web/src/lib/usePinnedTeams.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { PinnedTeam } from '@/types/pinnedTeams';
+
+const STORAGE_KEY = 'pinnedTeams';
+
+function readPinnedTeams(): PinnedTeam[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writePinnedTeams(teams: PinnedTeam[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(teams));
+}
+
+export function usePinnedTeams() {
+  const [mounted, setMounted] = useState(false);
+  const [pinnedTeams, setPinnedTeams] = useState<PinnedTeam[]>([]);
+
+  useEffect(() => {
+    setPinnedTeams(readPinnedTeams());
+    setMounted(true);
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        setPinnedTeams(readPinnedTeams());
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const pinTeam = useCallback((sport: string, teamCode: string, teamLabel: string) => {
+    setPinnedTeams(prev => {
+      if (prev.some(t => t.sport === sport && t.teamCode === teamCode)) return prev;
+      const next = [...prev, { sport, teamCode, teamLabel, pinnedAt: new Date().toISOString() }];
+      writePinnedTeams(next);
+      return next;
+    });
+  }, []);
+
+  const unpinTeam = useCallback((sport: string, teamCode: string) => {
+    setPinnedTeams(prev => {
+      const next = prev.filter(t => !(t.sport === sport && t.teamCode === teamCode));
+      writePinnedTeams(next);
+      return next;
+    });
+  }, []);
+
+  const isPinned = useCallback((sport: string, teamCode: string) => {
+    return pinnedTeams.some(t => t.sport === sport && t.teamCode === teamCode);
+  }, [pinnedTeams]);
+
+  const getPinnedForSport = useCallback((sport: string) => {
+    return pinnedTeams.filter(t => t.sport.toLowerCase() === sport.toLowerCase());
+  }, [pinnedTeams]);
+
+  return {
+    pinnedTeams: mounted ? pinnedTeams : [],
+    mounted,
+    pinTeam,
+    unpinTeam,
+    isPinned,
+    getPinnedForSport,
+  };
+}

--- a/web/src/types/pinnedTeams.ts
+++ b/web/src/types/pinnedTeams.ts
@@ -1,0 +1,19 @@
+export interface PinnedTeam {
+  sport: string;
+  teamCode: string;
+  teamLabel: string;
+  pinnedAt: string;
+}
+
+export interface TeamRosterEntry {
+  code: string;
+  longLabel: string;
+  conference: string;
+  division: string;
+}
+
+export interface TeamRoster {
+  sport: string;
+  lastUpdated: string;
+  teams: TeamRosterEntry[];
+}


### PR DESCRIPTION
## Summary
- Add `/settings/pinned-teams` page with three-panel UI for searching, selecting, and managing pinned teams across NFL, NBA, and NHL
- Add additive "Pinned Teams" dropdown filter to chart data tables with individual team selection
- Sort pinned team matchups first in matchup pages with blue left-border accent
- Add source attribution and fbrk.app footer to all chart PNG downloads/copies
- Update roadmap blog post with completed milestones

## Test plan
- [x] Visit `/settings/pinned-teams`, search and pin teams, verify localStorage persistence across reloads
- [x] Navigate to a sport page and verify pinned filter appears in table dropdowns with individual team options
- [x] Verify pinned filter is additive (pinned teams always shown alongside other filter results)
- [x] Check matchup pages sort pinned team games first with blue accent
- [x] Download/copy a chart PNG and verify source + fbrk.app footer appears
- [x] Test responsive layout on mobile (three panels stack vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)