### PR TITLE
Fix NBA/NHL playoff bracket series record and winner indicators

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/MLBMatchupWorksheet.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/MLBMatchupWorksheet.kt
@@ -297,32 +297,9 @@ private fun MLBMatchupContent(matchup: MLBMatchup, modifier: Modifier = Modifier
     val awayTeam = matchup.awayTeam
 
     Column(modifier = modifier.verticalScroll(rememberScrollState()).padding(start = 8.dp, end = 8.dp, top = 36.dp)) {
-        // Record section (matches NHL/NBA pattern)
-        MLBRecordSection(awayTeam = awayTeam, homeTeam = homeTeam)
-
-        // Location + date/time
-        matchup.location?.let { loc ->
-            Text(listOfNotNull(loc.stadium, loc.city).joinToString(", "),
-                style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth().padding(bottom = 2.dp), textAlign = TextAlign.Center)
-        }
-        if (!matchup.gameCompleted) {
-            val formatted = try { formatBracketGameDate(matchup.gameDate) } catch (_: Exception) { null }
-            formatted?.let {
-                Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center)
-            }
-        }
-
-        // Odds
-        matchup.odds?.let { odds ->
-            val parts = listOfNotNull(odds.details, odds.overUnder?.let { "O/U $it" })
-            if (parts.isNotEmpty()) {
-                Text(parts.joinToString("  •  "),
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.fillMaxWidth().padding(top = 2.dp), textAlign = TextAlign.Center)
-            }
-        }
+        // Record / location / odds — three rows, all using the same
+        // away-left / home-right horizontal alignment as the record row.
+        MLBMatchupMetaRows(matchup = matchup, awayTeam = awayTeam, homeTeam = homeTeam)
 
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -415,35 +392,86 @@ private fun MLBTeamStatsView(comparisons: MatchupComparisons, awayAbbrev: String
     }
 }
 
-// MLB Record Section (matches NHL/NBA record section layout)
+// Three-row meta section laid out as a 3-column grid (away | center | home).
+//   Row 1: stadium/city + date/time (centered, spans all columns)
+//   Row 2: away record | (center) | home record
+//   Row 3: away division | odds | home division
 @Composable
-private fun MLBRecordSection(awayTeam: MLBTeamInfo, homeTeam: MLBTeamInfo) {
-    val textStyle = MaterialTheme.typography.bodySmall.copy(lineHeight = 14.sp)
-    val textColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+private fun MLBMatchupMetaRows(
+    matchup: MLBMatchup,
+    awayTeam: MLBTeamInfo,
+    homeTeam: MLBTeamInfo
+) {
+    val textStyle = MaterialTheme.typography.labelSmall
+    val recordColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+    val metaColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val oddsColor = MaterialTheme.colorScheme.primary
 
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+    val formattedDate = if (!matchup.gameCompleted) {
+        try { formatBracketGameDate(matchup.gameDate) } catch (_: Exception) { null }
+    } else null
+    val stadiumLine = matchup.location?.let { loc ->
+        listOfNotNull(loc.stadium, loc.city).joinToString(", ").takeIf { it.isNotBlank() }
+    }
+    val locationLine = listOfNotNull(stadiumLine, formattedDate).joinToString(" • ").takeIf { it.isNotBlank() }
+    val oddsLine = matchup.odds?.let { odds ->
+        listOfNotNull(odds.details?.takeIf { it.isNotBlank() }, odds.overUnder?.let { "O/U $it" })
+            .joinToString(" • ").takeIf { it.isNotBlank() }
+    }
+
+    @Composable
+    fun ThreeColumnRow(
+        left: String?,
+        center: String?,
+        right: String?,
+        leftColor: Color,
+        centerColor: Color,
+        rightColor: Color
     ) {
-        // Away team (left)
-        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start) {
-            awayTeam.record?.let {
-                Text(it, style = textStyle, fontSize = 11.sp, color = textColor)
-            }
-            awayTeam.division?.let {
-                Text(it, style = textStyle, fontSize = 11.sp, color = textColor)
-            }
-        }
-        // Home team (right)
-        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.End) {
-            homeTeam.record?.let {
-                Text(it, style = textStyle, fontSize = 11.sp, color = textColor, textAlign = TextAlign.End)
-            }
-            homeTeam.division?.let {
-                Text(it, style = textStyle, fontSize = 11.sp, color = textColor, textAlign = TextAlign.End)
-            }
+        if (left == null && center == null && right == null) return
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                left ?: "",
+                style = textStyle, fontSize = 11.sp, color = leftColor,
+                modifier = Modifier.weight(1f), textAlign = TextAlign.Start
+            )
+            Text(
+                center ?: "",
+                style = textStyle, fontSize = 11.sp, color = centerColor,
+                modifier = Modifier.weight(1f), textAlign = TextAlign.Center
+            )
+            Text(
+                right ?: "",
+                style = textStyle, fontSize = 11.sp, color = rightColor,
+                modifier = Modifier.weight(1f), textAlign = TextAlign.End
+            )
         }
     }
+
+    // Row 1: stadium/city + date/time, centered across the full width
+    locationLine?.let {
+        Text(
+            it,
+            style = textStyle, fontSize = 11.sp, color = metaColor,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+
+    // Row 2: records (away left, home right), center reserved for alignment
+    ThreeColumnRow(
+        left = awayTeam.record, center = null, right = homeTeam.record,
+        leftColor = recordColor, centerColor = recordColor, rightColor = recordColor
+    )
+
+    // Row 3: division (away left, home right), odds in the center
+    ThreeColumnRow(
+        left = awayTeam.division, center = oddsLine, right = homeTeam.division,
+        leftColor = recordColor, centerColor = oddsColor, rightColor = recordColor
+    )
 }
 
 // MLB rank colors (30 teams)

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/PlayoffBracketCommon.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/PlayoffBracketCommon.kt
@@ -130,7 +130,7 @@ internal fun convertPlayoffMatchupToGame(matchup: PlayoffMatchupInfo?): PlayoffB
         return PlayoffBracketTeam(
             seed = info.seed, name = info.name,
             abbreviation = info.abbreviation ?: info.name.take(3).uppercase(),
-            seriesWins = info.score,
+            seriesWins = info.seriesWins,
             isWinner = isDecided && (isWinnerByName || info.isWinner)
         )
     }

--- a/pipeline/04-fastbreak-charts/daily/nba__playoff_bracket.R
+++ b/pipeline/04-fastbreak-charts/daily/nba__playoff_bracket.R
@@ -946,21 +946,40 @@ cat("Bracket status:", bracket_status, "\n")
 # Build a matchup (series wrapper) game object
 build_series_matchup <- function(team1, team2, conference, round_number, round_name,
                                  game_id, series_entry = NULL) {
+  # Reset state in case teams were carried over from an earlier round as winners.
+  team1$isWinner <- FALSE
+  team2$isWinner <- FALSE
+  team1$seriesWins <- NULL
+  team2$seriesWins <- NULL
+
   game_status <- "PROJECTED"
   series_summary <- NULL
   games_list <- list()
 
+  # Match a game competitor against a bracket team by ESPN numeric id first,
+  # falling back to abbreviation so we still count wins when abbreviation_id is
+  # missing (e.g. teams rehydrated from a minimal fallback record).
+  competitor_matches_team <- function(comp_id, comp_abbrev, team) {
+    if (!is.null(team$abbreviation_id) && length(team$abbreviation_id) > 0 &&
+        !is.null(comp_id) && length(comp_id) > 0 &&
+        as.character(comp_id) == as.character(team$abbreviation_id)) return(TRUE)
+    if (!is.null(team$abbreviation) && length(team$abbreviation) > 0 &&
+        !is.null(comp_abbrev) && length(comp_abbrev) > 0 &&
+        as.character(comp_abbrev) == as.character(team$abbreviation)) return(TRUE)
+    FALSE
+  }
+
   if (!is.null(series_entry)) {
     t1_wins <- sum(vapply(series_entry$games, function(g) {
       if (!isTRUE(g$completed)) return(0L)
-      if (as.character(g$team1_id) == as.character(team1$abbreviation_id) && isTRUE(g$team1_winner)) return(1L)
-      if (as.character(g$team2_id) == as.character(team1$abbreviation_id) && isTRUE(g$team2_winner)) return(1L)
+      if (competitor_matches_team(g$team1_id, g$team1_abbrev, team1) && isTRUE(g$team1_winner)) return(1L)
+      if (competitor_matches_team(g$team2_id, g$team2_abbrev, team1) && isTRUE(g$team2_winner)) return(1L)
       0L
     }, integer(1)))
     t2_wins <- sum(vapply(series_entry$games, function(g) {
       if (!isTRUE(g$completed)) return(0L)
-      if (as.character(g$team1_id) == as.character(team2$abbreviation_id) && isTRUE(g$team1_winner)) return(1L)
-      if (as.character(g$team2_id) == as.character(team2$abbreviation_id) && isTRUE(g$team2_winner)) return(1L)
+      if (competitor_matches_team(g$team1_id, g$team1_abbrev, team2) && isTRUE(g$team1_winner)) return(1L)
+      if (competitor_matches_team(g$team2_id, g$team2_abbrev, team2) && isTRUE(g$team2_winner)) return(1L)
       0L
     }, integer(1)))
 
@@ -979,24 +998,50 @@ build_series_matchup <- function(team1, team2, conference, round_number, round_n
       game_status <- "SCHEDULED"
     }
 
+    # Normalize each game so team1 always refers to the matchup's team1 (the
+    # "left" column in the KMP series tab). ESPN can list home/away in either
+    # order across games in the same series, so without this the per-game
+    # winner indicator can end up on the wrong side.
     games_list <- lapply(series_entry$games, function(g) {
-      list(
-        gameId = g$game_id,
-        gameDate = g$game_date,
-        status = g$status,
-        completed = g$completed,
-        headline = g$headline,
-        homeTeamAbbrev = g$homeTeamAbbrev,
-        team1 = list(
-          abbreviation = g$team1_abbrev, score = g$team1_score,
-          winner = g$team1_winner
-        ),
-        team2 = list(
-          abbreviation = g$team2_abbrev, score = g$team2_score,
-          winner = g$team2_winner
-        ),
-        odds = g$odds
-      )
+      swap <- competitor_matches_team(g$team2_id, g$team2_abbrev, team1) ||
+              competitor_matches_team(g$team1_id, g$team1_abbrev, team2)
+      if (swap) {
+        list(
+          gameId = g$game_id,
+          gameDate = g$game_date,
+          status = g$status,
+          completed = g$completed,
+          headline = g$headline,
+          homeTeamAbbrev = g$homeTeamAbbrev,
+          team1 = list(
+            abbreviation = g$team2_abbrev, score = g$team2_score,
+            winner = g$team2_winner
+          ),
+          team2 = list(
+            abbreviation = g$team1_abbrev, score = g$team1_score,
+            winner = g$team1_winner
+          ),
+          odds = g$odds
+        )
+      } else {
+        list(
+          gameId = g$game_id,
+          gameDate = g$game_date,
+          status = g$status,
+          completed = g$completed,
+          headline = g$headline,
+          homeTeamAbbrev = g$homeTeamAbbrev,
+          team1 = list(
+            abbreviation = g$team1_abbrev, score = g$team1_score,
+            winner = g$team1_winner
+          ),
+          team2 = list(
+            abbreviation = g$team2_abbrev, score = g$team2_score,
+            winner = g$team2_winner
+          ),
+          odds = g$odds
+        )
+      }
     })
   }
 

--- a/pipeline/04-fastbreak-charts/daily/nhl__playoff_bracket.R
+++ b/pipeline/04-fastbreak-charts/daily/nhl__playoff_bracket.R
@@ -897,6 +897,12 @@ has_playoff_games <- length(playoff_events) > 0
 bracket_status <- if (!has_playoff_games) "PROJECTED" else if (today > PLAYOFFS_END) "COMPLETED" else "IN_PROGRESS"
 
 build_series_matchup <- function(team1, team2, conference, round_number, round_name, game_id, series_entry = NULL) {
+  # Reset state in case teams were carried over from an earlier round as winners.
+  team1$isWinner <- FALSE
+  team2$isWinner <- FALSE
+  team1$seriesWins <- NULL
+  team2$seriesWins <- NULL
+
   game_status <- "PROJECTED"
   series_summary <- NULL
   games_list <- list()
@@ -927,12 +933,26 @@ build_series_matchup <- function(team1, team2, conference, round_number, round_n
     } else if (t1_wins > 0 || t2_wins > 0) { game_status <- "IN_PROGRESS"
     } else { game_status <- "SCHEDULED" }
 
+    # Normalize each game so team1 always refers to the matchup's team1 (the
+    # "left" column in the KMP series tab). ESPN can list home/away in either
+    # order across games in the same series, so without this the per-game
+    # winner indicator can end up on the wrong side.
     games_list <- lapply(series_entry$games, function(g) {
-      list(gameId = g$game_id, gameDate = g$game_date, status = g$status, completed = g$completed,
-           homeTeamAbbrev = g$home_abbrev,
-           team1 = list(abbreviation = g$team1_abbrev, score = g$team1_score, winner = g$team1_winner),
-           team2 = list(abbreviation = g$team2_abbrev, score = g$team2_score, winner = g$team2_winner),
-           odds = g$odds)
+      swap <- !is.null(team1$abbreviation) && !is.null(g$team2_abbrev) &&
+              g$team2_abbrev == team1$abbreviation
+      if (swap) {
+        list(gameId = g$game_id, gameDate = g$game_date, status = g$status, completed = g$completed,
+             homeTeamAbbrev = g$home_abbrev,
+             team1 = list(abbreviation = g$team2_abbrev, score = g$team2_score, winner = g$team2_winner),
+             team2 = list(abbreviation = g$team1_abbrev, score = g$team1_score, winner = g$team1_winner),
+             odds = g$odds)
+      } else {
+        list(gameId = g$game_id, gameDate = g$game_date, status = g$status, completed = g$completed,
+             homeTeamAbbrev = g$home_abbrev,
+             team1 = list(abbreviation = g$team1_abbrev, score = g$team1_score, winner = g$team1_winner),
+             team2 = list(abbreviation = g$team2_abbrev, score = g$team2_score, winner = g$team2_winner),
+             odds = g$odds)
+      }
     })
   }
 


### PR DESCRIPTION
The bracket node was pulling each team's series record from `info.score`
(used only for NCAA tournaments), so the series win count always stayed
at 0 on the bracket even when games showed up in the Series tab. Read
`info.seriesWins` instead so completed games actually update the record.

The R scripts also had two issues the KMP app exposed:

- When a round-1 winner was passed into round 2 before ESPN had any
  round-2 games, the carried-over `isWinner`/`seriesWins` state from
  round 1 leaked into the next matchup. Reset both at the start of
  build_series_matchup so each round recomputes cleanly.
- ESPN can list home/away in either order across games in the same
  series, so game.team1 didn't always correspond to the matchup's
  team1 (the left column in the Series tab). Normalize each game to
  match the matchup ordering so the per-game winner indicator lines
  up with the correct side.

For NBA also fall back to abbreviation matching when a team's ESPN
numeric id isn't available (e.g. rehydrated from a minimal record),
so series wins still get counted.

https://claude.ai/code/session_01JaNfUsv8cSFbJXZu2smQFg