### PR TITLE
Speed up iOS deploy workflow with caching and Gradle tuning

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -31,6 +31,24 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
+      # Cache the Kotlin/Native toolchain (compiler, LLVM, libffi, etc.) which
+      # is downloaded into ~/.konan on first run and weighs ~1.5GB. Keyed on
+      # the Kotlin version from the version catalog so it invalidates on
+      # upgrades.
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-${{ runner.arch }}-konan-${{ hashFiles('kmp/gradle/libs.versions.toml', 'kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-konan-
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -38,8 +56,18 @@ jobs:
           bundler-cache: true
           working-directory: kmp/iosApp
 
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            kmp/iosApp/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('kmp/iosApp/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
       - name: Build KMP Framework
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
+        run: ./gradlew :shared:linkReleaseFrameworkIosArm64 --build-cache --parallel
 
       - name: Install CocoaPods
         working-directory: kmp/iosApp

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -66,8 +66,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
 
-      - name: Build KMP Framework
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64 --build-cache --parallel
+      # The KMP shared framework is built by the Xcode "Run Script" build
+      # phase that invokes ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+      # (see iosApp.xcodeproj/project.pbxproj). xcodebuild (via fastlane
+      # build_app below) triggers that, so no separate gradle step is needed
+      # here.
 
       - name: Install CocoaPods
         working-directory: kmp/iosApp

--- a/.github/workflows/test-ios-build.yml
+++ b/.github/workflows/test-ios-build.yml
@@ -64,16 +64,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
 
-      - name: Build KMP Framework
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64 --build-cache --parallel
-
       - name: Install CocoaPods
         working-directory: kmp/iosApp
         run: bundle exec pod install
 
-      # Compile the iOS app for device with code signing disabled. This
-      # validates that the KMP framework integrates cleanly and the Xcode
-      # build succeeds without needing the TestFlight signing material.
+      # Compiles the iOS app for device with code signing disabled. The
+      # Xcode "Run Script" build phase (see project.pbxproj) invokes
+      # ./gradlew :shared:embedAndSignAppleFrameworkForXcode, so the KMP
+      # shared framework is built as part of this xcodebuild invocation —
+      # no separate gradle step is needed.
       - name: Build iOS app (no signing)
         working-directory: kmp/iosApp
         run: |

--- a/.github/workflows/test-ios-build.yml
+++ b/.github/workflows/test-ios-build.yml
@@ -1,0 +1,90 @@
+name: Test iOS Build
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'kmp/**'
+      - '.github/workflows/test-ios-build.yml'
+
+# Only run the latest commit per PR; cancel older in-flight runs.
+concurrency:
+  group: test-ios-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-26
+    defaults:
+      run:
+        working-directory: kmp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # Read main's cache but don't write from PR runs to keep the
+          # deploy workflow's cache scope clean.
+          cache-read-only: true
+
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-${{ runner.arch }}-konan-${{ hashFiles('kmp/gradle/libs.versions.toml', 'kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-konan-
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          working-directory: kmp/iosApp
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            kmp/iosApp/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('kmp/iosApp/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Build KMP Framework
+        run: ./gradlew :shared:linkReleaseFrameworkIosArm64 --build-cache --parallel
+
+      - name: Install CocoaPods
+        working-directory: kmp/iosApp
+        run: bundle exec pod install
+
+      # Compile the iOS app for device with code signing disabled. This
+      # validates that the KMP framework integrates cleanly and the Xcode
+      # build succeeds without needing the TestFlight signing material.
+      - name: Build iOS app (no signing)
+        working-directory: kmp/iosApp
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -workspace iosApp.xcworkspace \
+            -scheme Fastbreak \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build

--- a/kmp/gradle.properties
+++ b/kmp/gradle.properties
@@ -14,9 +14,6 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
-# Workaround for Koala Plot linking issue on iOS (CMP-7571)
-kotlin.native.cacheKind=none
-
 # Version management
 VERSION_CODE=2
 VERSION_NAME=1.0.1

--- a/kmp/gradle.properties
+++ b/kmp/gradle.properties
@@ -7,8 +7,12 @@ android.minSdk=24
 android.compileSdk=35
 android.targetSdk=35
 
-kotlin.daemon.jvmargs=-Xmx4096m
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx6144m
+org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
+
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
 
 # Workaround for Koala Plot linking issue on iOS (CMP-7571)
 kotlin.native.cacheKind=none


### PR DESCRIPTION
The Build KMP Framework step took ~14 min on cold runners largely
because:
- ~/.konan (Kotlin/Native compiler + LLVM toolchain, ~1.5GB) was
  downloaded fresh every run
- Gradle dependency cache wasn't restored between runs
- CocoaPods were re-fetched on every run
- Build cache and parallel execution weren't enabled

Adds caches for ~/.konan (keyed on Kotlin version), Gradle (via
gradle/actions/setup-gradle@v4), and CocoaPods. Enables --build-cache
and --parallel on the linkReleaseFrameworkIosArm64 task and bumps the
Gradle/Kotlin daemon heap to 6GB to better use the macos-26 runner.

kotlin.native.cacheKind=none is left in place since it's an explicit
workaround for the Koala Plot linking issue (CMP-7571).