### PR TITLE
Fix topics unread indicator showing on fresh install

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/TopicsRepository.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/TopicsRepository.kt
@@ -120,7 +120,10 @@ class TopicsRepository(
      * @return true if topics have been viewed, false otherwise
      */
     fun hasBeenViewed(): Boolean {
-        return settings.getBoolean(KEY_TOPICS_VIEWED, false)
+        // Default to true so the "unread" indicator does not appear on a fresh
+        // install before any topics have been downloaded. resetViewed() is
+        // called whenever new topics arrive, which flips this to false.
+        return settings.getBoolean(KEY_TOPICS_VIEWED, true)
     }
 
     /**


### PR DESCRIPTION
## Summary

The Topics tab icon was displaying the "unread" indicator on a freshly installed app before any topic or chart data had been downloaded.

## Root cause

`TopicsRepository.hasBeenViewed()` defaulted to `false` when the `topics_viewed` key was missing from settings. The UI in `HomeScreen.kt` shows the indicator when `!topicsViewed`, so a fresh install (no key set) was treated identically to "new topics downloaded but not yet viewed."

## Fix

Flip the default to `true` in `hasBeenViewed()`. The unread state is only meaningful after topics have actually been fetched — `ChartDataSynchronizer.synchronizeTopics()` calls `resetViewed()` whenever new topics arrive, which explicitly writes `false` and produces the indicator at the correct time. `markAsViewed()` later flips it back to `true`.

## Test plan

- [ ] Fresh install (clear app data) → open app → Topics icon shows **no** unread indicator
- [ ] Wait for topics to download → indicator appears
- [ ] Tap Topics, view, return → indicator disappears
- [ ] New topics published later → indicator reappears

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgReJ7VzXZW4Xn7K3NsxrS)_