### PR TITLE
Retry chart downloads on cold-start network failures

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/api/HttpClientFactory.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/api/HttpClientFactory.kt
@@ -31,9 +31,13 @@ object HttpClientFactory {
                 socketTimeoutMillis = 30_000 // 30 seconds
             }
 
-            // Add default request configuration
+            // Retry on transient failures. Cold-start on a fresh install often
+            // hits DNS/connect timeouts on the first few requests; without
+            // retryOnException those charts fail silently and only get
+            // downloaded on the next refresh tap.
             install(HttpRequestRetry) {
                 retryOnServerErrors(maxRetries = 2)
+                retryOnException(maxRetries = 3, retryOnTimeout = true)
                 exponentialDelay()
             }
         }

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
@@ -31,6 +31,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -181,6 +182,9 @@ class ChartDataSynchronizer(
                         stateMutex.withLock {
                             syncedCharts.add(chartId)
                         }
+                    } catch (e: CancellationException) {
+                        // Propagate cancellation so structured concurrency works
+                        throw e
                     } catch (e: Exception) {
                         // Log error but continue with other charts
                         println("❌ Failed to sync chart '${entry.title}': ${e.message}")


### PR DESCRIPTION
## Summary

On a fresh install, the first tap of "Refresh Registry" downloads only a subset of charts and stops without showing an error; a second tap downloads the rest. Likely cause and fix:

- The shared Ktor `HttpClientFactory` only retried 5xx responses (`retryOnServerErrors`). On a fresh install, the first few chart requests hit cold DNS/TCP and fail with connect timeouts or socket errors. Those exceptions bubble into `ChartDataSynchronizer`'s per-chart `catch`, which records the chart in `failedCharts` and moves on — silently from the user's perspective, because the "Failed to sync N charts" toast is wired only to `HomeScreen` and the user triggered the refresh from `SettingsScreen`. The second tap succeeds because the network is now warm.
- `ChartDataSynchronizer`'s per-chart `catch (e: Exception)` also swallowed `CancellationException`, which breaks structured concurrency cleanup.

Changes:
- `HttpClientFactory`: add `retryOnException(maxRetries = 3, retryOnTimeout = true)` alongside the existing 5xx retry so transient connect/timeout failures retry instead of permanently failing the chart.
- `ChartDataSynchronizer`: rethrow `CancellationException` before the generic exception handler.

## Test plan
- [ ] Fresh install, tap "Refresh Registry" from Settings on a cold network: all charts download in a single pass.
- [ ] Airplane-mode toggle mid-sync to confirm cancellation still propagates cleanly.
- [ ] Existing happy-path refresh (warm network) still completes without regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEY3URVSUxTwwX6yZffb8L)_