### PR TITLE
Fix playoff round parsing regex order to prevent misclassification

### DIFF
--- a/pipeline/04-fastbreak-charts/daily/nba__playoff_bracket.R
+++ b/pipeline/04-fastbreak-charts/daily/nba__playoff_bracket.R
@@ -90,16 +90,25 @@ parse_playoff_round <- function(headline) {
 
   round_num <- NA
   round_name <- NA
-  if (grepl("finals", hl) && !grepl("conf", hl) && is.na(conference)) {
-    round_num <- 4; round_name <- "NBA Finals"; conference <- "Finals"
-  } else if (grepl("conf(\\.|erence)? finals", hl)) {
-    round_num <- 3; round_name <- "Conference Finals"
-  } else if (grepl("conf(\\.|erence)? semifinals|semifinals", hl)) {
-    round_num <- 2; round_name <- "Conference Semifinals"
+  if (grepl("play-in|play in", hl)) {
+    round_num <- 0; round_name <- "Play-In"
   } else if (grepl("first round|1st round|round 1", hl)) {
     round_num <- 1; round_name <- "First Round"
-  } else if (grepl("play-in|play in", hl)) {
-    round_num <- 0; round_name <- "Play-In"
+  } else if (grepl("semifinal", hl)) {
+    # Match semifinals BEFORE the "final" branch below so that
+    # "Conference Semifinals" headlines aren't picked up as Conference Finals
+    # via a loose substring match.
+    round_num <- 2; round_name <- "Conference Semifinals"
+  } else if (grepl("finals?", hl)) {
+    # Any other "final"/"finals" mention. If a conference (East/West) was
+    # detected in the headline this is a Conference Finals series; otherwise
+    # it's the league-level NBA Finals. Accepts headlines that abbreviate or
+    # drop the word "Conference" (e.g. "Eastern Finals").
+    if (is.na(conference)) {
+      round_num <- 4; round_name <- "NBA Finals"; conference <- "Finals"
+    } else {
+      round_num <- 3; round_name <- "Conference Finals"
+    }
   }
 
   list(conference = conference, roundNumber = round_num, roundName = round_name)

--- a/pipeline/04-fastbreak-charts/daily/nhl__playoff_bracket.R
+++ b/pipeline/04-fastbreak-charts/daily/nhl__playoff_bracket.R
@@ -793,12 +793,16 @@ parse_nhl_playoff_round <- function(headline) {
   round_num <- NA; round_name <- NA
   if (grepl("stanley cup final", hl)) {
     round_num <- 4; round_name <- "Stanley Cup Final"; conference <- "Finals"
-  } else if (grepl("conf.*final", hl)) {
-    round_num <- 3; round_name <- "Conference Finals"
-  } else if (grepl("2nd round|second round|semifinals", hl)) {
-    round_num <- 2; round_name <- "Conference Semifinals"
   } else if (grepl("1st round|first round", hl)) {
     round_num <- 1; round_name <- "First Round"
+  } else if (grepl("2nd round|second round|semifinal", hl)) {
+    # Check semifinals BEFORE the "final" branch below — otherwise a loose
+    # "conf.*final" match consumes "conference semifinals" (the "final" inside
+    # "semifinals") and classifies R2 games as R3, leaving the Conference
+    # Finals filter contaminated with stale semifinal series.
+    round_num <- 2; round_name <- "Conference Semifinals"
+  } else if (grepl("final", hl)) {
+    round_num <- 3; round_name <- "Conference Finals"
   }
   list(conference = conference, roundNumber = round_num, roundName = round_name)
 }


### PR DESCRIPTION
## Summary
Reordered conditional checks in playoff bracket parsing functions for both NBA and NHL to prevent regex patterns from incorrectly matching and misclassifying playoff rounds. The issue occurred when broader patterns (like "final") would match substrings within more specific round names (like "semifinals"), causing rounds to be classified at the wrong level.

## Key Changes
- **NBA playoff bracket parser**: Reorganized the round detection logic to check for "Play-In" first, then "First Round", then "semifinal" (before any "final" checks), and finally a generalized "finals?" pattern that distinguishes between NBA Finals and Conference Finals based on conference detection
- **NHL playoff bracket parser**: Applied the same fix by checking for "1st/first round" before "2nd/second round/semifinal", and moving the generic "final" check last to catch Conference Finals without interfering with semifinal classification
- Added clarifying comments explaining why the order matters and the specific issue being prevented

## Implementation Details
The root cause was that patterns like `grepl("conf.*final", hl)` would match "Conference Semifinals" (matching the "final" substring within "semifinals"), causing R2 games to be misclassified as R3. By checking for the more specific "semifinal" pattern before the broader "final" pattern, the correct round is now assigned. The generalized "finals?" pattern now serves as a catch-all for any remaining finals-related headlines, with logic to distinguish between league-level and conference-level finals based on whether a conference was detected in the headline.

https://claude.ai/code/session_01SKTxb4Rt4XNuFDNraEM3tG