### PR TITLE
Only generate release ID when both kmp and charts change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
         working-directory: server/src/Fastbreak.Daily
 
       - name: Update Release ID in DynamoDB
+        if: needs.detect-changes.outputs.kmp == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/kmp/gradle.properties
+++ b/kmp/gradle.properties
@@ -20,3 +20,4 @@ VERSION_NAME=1.2.0
 # Fastbreak config
 dev_mode=false
 built_in_release_id=fb-1
+# release id sync

--- a/pipeline/04-fastbreak-charts/README.md
+++ b/pipeline/04-fastbreak-charts/README.md
@@ -27,3 +27,5 @@ docker run -d --env-file .env --name fastbreak-charts fastbreak-charts
 - All R scripts in respective folders execute automatically
 - Scripts run immediately on container startup
 - JSON output saved to `/app/output` (mounted to `/Users/joebad/Source/fastbreak/server/nginx/static`)
+
+<!-- release id sync -->


### PR DESCRIPTION
## Summary

- The release ID was being bumped on every charts deploy (pipeline OR server changes), which caused it to drift out of sync with kmp builds.
- Gates the DynamoDB `Update Release ID` step on `kmp == 'true'` so a new release ID is only generated when a commit touches **both** kmp AND (pipeline OR server).
- Adds trivial markers in `kmp/gradle.properties` and `pipeline/04-fastbreak-charts/README.md` so merging this PR satisfies both conditions and produces a fresh release ID under the new rule, re-syncing prod.

## Behavior matrix

| kmp changed | charts changed | deploy-charts runs | release ID bumped | android/ios build |
|---|---|---|---|---|
| no  | no  | no  | no  | no  |
| no  | yes | yes | **no** (new) | no |
| yes | no  | no  | no  | yes (uses existing ID) |
| yes | yes | yes | **yes** | yes |

## Test plan
- [ ] Merge to main and confirm the deploy workflow runs `deploy-charts`, `deploy-android`, and `deploy-ios`.
- [ ] Confirm the DynamoDB `prod/system/releaseId` item updates to the new `fb-${BUILD_NUMBER}`.
- [ ] Confirm the android/ios builds embed that same release ID.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYyb5Vv3T3qWMTXsLB2BuV)_