### PR TITLE
Surface silent save failures and harden chart-index writes

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/ChartDataRepository.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/ChartDataRepository.kt
@@ -43,17 +43,24 @@ class ChartDataRepository(
         indexMutex.withLock { saveChartDataLocked(chartId, data) }
     }
 
+    // Why: the previous version caught SerializationException silently AND called
+    // getAllChartIds() which itself swallows decode failures by returning emptyList().
+    // Combined, a decode failure on the index produced a destructive
+    // "wipe the index, persist only this chart" overwrite — the data keys stayed
+    // but every previously-saved chart became invisible to buildRegistryFromCache.
+    // Now we serialize everything up front and read the index via the throwing
+    // variant; a decode failure aborts the write instead of corrupting the index,
+    // and the exception surfaces in failedCharts.
     private fun saveChartDataLocked(chartId: String, data: CachedChartData) {
-        try {
-            val jsonString = json.encodeToString(data)
-            settings.putString("$PREFIX_CHART$chartId", jsonString)
+        val dataJson = json.encodeToString(data)
+        val currentIds = readChartIdsIndexOrThrow().toMutableSet()
+        val updatedIndexJson = if (currentIds.add(chartId)) {
+            json.encodeToString(currentIds.toList())
+        } else null
 
-            val currentIds = getAllChartIds().toMutableSet()
-            if (currentIds.add(chartId)) {
-                saveChartIds(currentIds.toList())
-            }
-        } catch (e: SerializationException) {
-            println("Error saving chart data for $chartId: ${e.message}")
+        settings.putString("$PREFIX_CHART$chartId", dataJson)
+        if (updatedIndexJson != null) {
+            settings.putString(KEY_CHART_IDS, updatedIndexJson)
         }
     }
 
@@ -95,12 +102,16 @@ class ChartDataRepository(
      * Gets the list of all cached chart IDs.
      * This list is stored separately to avoid iterating through all keys.
      *
+     * Returns an empty list if the index can't be decoded — safe for diagnostic
+     * and read-only callers. Code paths that MODIFY the index must use
+     * [readChartIdsIndexOrThrow] instead, since treating a decode failure as
+     * "empty" during a read-modify-write would silently wipe the index.
+     *
      * @return List of chart IDs that have cached data
      */
     fun getAllChartIds(): List<String> {
         return try {
-            val jsonString = settings.getStringOrNull(KEY_CHART_IDS) ?: return emptyList()
-            json.decodeFromString<List<String>>(jsonString)
+            readChartIdsIndexOrThrow()
         } catch (e: SerializationException) {
             println("Error reading chart IDs: ${e.message}")
             emptyList()
@@ -108,18 +119,16 @@ class ChartDataRepository(
     }
 
     /**
-     * Saves the list of chart IDs to storage.
-     * This is called internally when charts are added or removed.
+     * Reads the chart IDs index from storage, propagating decode failures.
      *
-     * @param ids List of chart IDs to save
+     * Used inside [saveChartDataLocked] and [deleteChartDataLocked] to protect
+     * the index from being overwritten with partial data if the stored JSON is
+     * unreadable. Callers that just want a best-effort read should use
+     * [getAllChartIds] instead.
      */
-    private fun saveChartIds(ids: List<String>) {
-        try {
-            val jsonString = json.encodeToString(ids)
-            settings.putString(KEY_CHART_IDS, jsonString)
-        } catch (e: SerializationException) {
-            println("Error saving chart IDs: ${e.message}")
-        }
+    private fun readChartIdsIndexOrThrow(): List<String> {
+        val jsonString = settings.getStringOrNull(KEY_CHART_IDS) ?: return emptyList()
+        return json.decodeFromString<List<String>>(jsonString)
     }
 
     /**
@@ -133,11 +142,14 @@ class ChartDataRepository(
     }
 
     private fun deleteChartDataLocked(chartId: String) {
-        settings.remove("$PREFIX_CHART$chartId")
+        val currentIds = readChartIdsIndexOrThrow().toMutableSet()
+        val updatedIndexJson = if (currentIds.remove(chartId)) {
+            json.encodeToString(currentIds.toList())
+        } else null
 
-        val currentIds = getAllChartIds().toMutableSet()
-        if (currentIds.remove(chartId)) {
-            saveChartIds(currentIds.toList())
+        settings.remove("$PREFIX_CHART$chartId")
+        if (updatedIndexJson != null) {
+            settings.putString(KEY_CHART_IDS, updatedIndexJson)
         }
     }
 

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/RegistryRepository.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/RegistryRepository.kt
@@ -36,14 +36,15 @@ class RegistryRepository(
         entries.forEach { (key, entry) ->
             println("   - $key: ${entry.title} (updatedAt: ${entry.updatedAt})")
         }
-        try {
-            val jsonString = json.encodeToString(entries)
-            println("   JSON size: ${jsonString.length} chars")
-            settings.putString(KEY_REGISTRY_ENTRIES, jsonString)
-            println("   ✅ Saved successfully")
-        } catch (e: SerializationException) {
-            println("   ❌ Error saving registry entries: ${e.message}")
-        }
+        // Why: previously caught SerializationException silently here, which let a
+        // failed save look identical to a successful one. The caller (RegistryManager)
+        // already wraps this in runCatching, so propagating the exception lets it
+        // surface as a refresh failure instead of producing a "succeeded but cache
+        // is empty" state.
+        val jsonString = json.encodeToString(entries)
+        println("   JSON size: ${jsonString.length} chars")
+        settings.putString(KEY_REGISTRY_ENTRIES, jsonString)
+        println("   ✅ Saved successfully")
     }
 
     /**
@@ -81,13 +82,13 @@ class RegistryRepository(
         println("💾 RegistryRepository.saveMetadata()")
         println("   lastDownloadTime: ${metadata.lastDownloadTime}")
         println("   registryVersion: ${metadata.registryVersion}")
-        try {
-            val jsonString = json.encodeToString(metadata)
-            settings.putString(KEY_METADATA, jsonString)
-            println("   ✅ Metadata saved successfully")
-        } catch (e: SerializationException) {
-            println("   ❌ Error saving registry metadata: ${e.message}")
-        }
+        // Why: silent failure here was the most likely explanation for the "Stale"
+        // indicator persisting after a refresh — metadata never lands, so
+        // isRegistryStale() returns true even though entries were just fetched.
+        // Propagate so it surfaces as a refresh failure.
+        val jsonString = json.encodeToString(metadata)
+        settings.putString(KEY_METADATA, jsonString)
+        println("   ✅ Metadata saved successfully")
     }
 
     /**

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
@@ -360,6 +360,19 @@ class ChartDataSynchronizer(
             chartDataRepository.saveChartData(chartId, cachedData)
             println("✅ Chart $chartId saved to cache")
 
+            // Verify the save actually landed in both the data store AND the index.
+            // Without this, a silent storage failure or index inconsistency leaves the
+            // chart visible to syncedCharts but invisible to buildRegistryFromCache,
+            // which is exactly the "downloads succeed but charts don't show" symptom.
+            // Throwing here routes the failure into the per-chart catch block and onto
+            // failedCharts, so the user sees a toast and Sentry gets the exception.
+            check(chartDataRepository.hasChartData(chartId)) {
+                "Chart data missing from cache after save: $chartId"
+            }
+            check(chartDataRepository.getAllChartIds().contains(chartId)) {
+                "Chart $chartId missing from index after save (index size=${chartDataRepository.getAllChartIds().size})"
+            }
+
             SentryLogger.finishSpan(spanId, SpanStatus.OK)
 
             SentryLogger.addBreadcrumb(


### PR DESCRIPTION
## Summary

First-refresh-after-install was producing partial chart lists with no failure toasts and a "Stale" status in Settings, where a second refresh always fixed it. Tracing the write path, three swallowed `SerializationException` catches could silently desync the cache from the server, and one read-modify-write on the chart IDs index was destructive when the underlying read failed.

## What changed

- **`ChartDataRepository.saveChartDataLocked`** previously called `getAllChartIds()`, which swallows decode failures and returns `emptyList()`. On a mid-sync decode failure, the subsequent `saveChartIds(listOf(currentId))` would overwrite the entire index with only the current chart — every previously-saved chart's data stayed on disk but became invisible to `buildRegistryFromCache`. Both swallows are now loud, and the read-modify-write reads via a new private `readChartIdsIndexOrThrow` so a decode failure aborts the write instead of corrupting the index. `deleteChartDataLocked` uses the same throwing read for consistency.
- **`RegistryRepository.saveMetadata` / `saveRegistryEntries`** swallowed `SerializationException`. The metadata swallow is the most likely explanation for "Stale" persisting after a refresh — metadata never lands, so `isRegistryStale()` stays true. Both now propagate so failures surface as refresh errors via the existing `runCatching` in `RegistryManager`, instead of producing a "succeeded but cache is empty" state.
- **`ChartDataSynchronizer.downloadAndCacheChart`** now verifies after `saveChartData` that the chart is present in both the data store (`hasChartData`) and the index (`getAllChartIds().contains`), throwing if either is missing. This turns "silent skip" into a per-chart failure routed through `failedCharts` and Sentry, enforcing the invariant that a successful refresh leaves the cache matching the server.

## Why this matches the symptoms

- Partial cache + no toasts ⇒ a save thought it succeeded but didn't land. The two silent catches were the only paths in the write chain where that could happen without going through `failedCharts`.
- "Stale" indicator after refresh ⇒ same root cause in `saveMetadata`. Removing the swallow makes the failure visible if it fires again.
- Second refresh resolving it ⇒ on the next pass, `needsUpdate` keys off `getChartData(chart_<id>)` directly, so it correctly identifies the charts whose data never landed and re-downloads them.

## Test plan

- [ ] Fresh install → first refresh should populate all charts. If a save fails for any reason, a toast appears and the chart is listed in Settings → sync status.
- [ ] Confirm "Stale" no longer persists after a successful refresh on first install.
- [ ] Background regression: second refresh / pull-to-refresh / `resetAllData` followed by refresh continues to work.
- [ ] If the bug repros after this change, the failure now surfaces (toast + Sentry exception) instead of silently producing a partial cache — that will tell us which exception is firing.

## Notes

- I couldn't run `:shared:compileKotlinMetadata` from the sandbox (no network access to the Google Maven plugin repo). Verified the diff manually; please run a local build before merging.

https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF)_