### PR TITLE
Build registry from server entries with placeholders during sync

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/ChartDataRepository.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/ChartDataRepository.kt
@@ -43,17 +43,24 @@ class ChartDataRepository(
         indexMutex.withLock { saveChartDataLocked(chartId, data) }
     }
 
+    // Why: the previous version caught SerializationException silently AND called
+    // getAllChartIds() which itself swallows decode failures by returning emptyList().
+    // Combined, a decode failure on the index produced a destructive
+    // "wipe the index, persist only this chart" overwrite — the data keys stayed
+    // but every previously-saved chart became invisible to buildRegistryFromCache.
+    // Now we serialize everything up front and read the index via the throwing
+    // variant; a decode failure aborts the write instead of corrupting the index,
+    // and the exception surfaces in failedCharts.
     private fun saveChartDataLocked(chartId: String, data: CachedChartData) {
-        try {
-            val jsonString = json.encodeToString(data)
-            settings.putString("$PREFIX_CHART$chartId", jsonString)
+        val dataJson = json.encodeToString(data)
+        val currentIds = readChartIdsIndexOrThrow().toMutableSet()
+        val updatedIndexJson = if (currentIds.add(chartId)) {
+            json.encodeToString(currentIds.toList())
+        } else null
 
-            val currentIds = getAllChartIds().toMutableSet()
-            if (currentIds.add(chartId)) {
-                saveChartIds(currentIds.toList())
-            }
-        } catch (e: SerializationException) {
-            println("Error saving chart data for $chartId: ${e.message}")
+        settings.putString("$PREFIX_CHART$chartId", dataJson)
+        if (updatedIndexJson != null) {
+            settings.putString(KEY_CHART_IDS, updatedIndexJson)
         }
     }
 
@@ -95,12 +102,16 @@ class ChartDataRepository(
      * Gets the list of all cached chart IDs.
      * This list is stored separately to avoid iterating through all keys.
      *
+     * Returns an empty list if the index can't be decoded — safe for diagnostic
+     * and read-only callers. Code paths that MODIFY the index must use
+     * [readChartIdsIndexOrThrow] instead, since treating a decode failure as
+     * "empty" during a read-modify-write would silently wipe the index.
+     *
      * @return List of chart IDs that have cached data
      */
     fun getAllChartIds(): List<String> {
         return try {
-            val jsonString = settings.getStringOrNull(KEY_CHART_IDS) ?: return emptyList()
-            json.decodeFromString<List<String>>(jsonString)
+            readChartIdsIndexOrThrow()
         } catch (e: SerializationException) {
             println("Error reading chart IDs: ${e.message}")
             emptyList()
@@ -108,18 +119,16 @@ class ChartDataRepository(
     }
 
     /**
-     * Saves the list of chart IDs to storage.
-     * This is called internally when charts are added or removed.
+     * Reads the chart IDs index from storage, propagating decode failures.
      *
-     * @param ids List of chart IDs to save
+     * Used inside [saveChartDataLocked] and [deleteChartDataLocked] to protect
+     * the index from being overwritten with partial data if the stored JSON is
+     * unreadable. Callers that just want a best-effort read should use
+     * [getAllChartIds] instead.
      */
-    private fun saveChartIds(ids: List<String>) {
-        try {
-            val jsonString = json.encodeToString(ids)
-            settings.putString(KEY_CHART_IDS, jsonString)
-        } catch (e: SerializationException) {
-            println("Error saving chart IDs: ${e.message}")
-        }
+    private fun readChartIdsIndexOrThrow(): List<String> {
+        val jsonString = settings.getStringOrNull(KEY_CHART_IDS) ?: return emptyList()
+        return json.decodeFromString<List<String>>(jsonString)
     }
 
     /**
@@ -133,11 +142,14 @@ class ChartDataRepository(
     }
 
     private fun deleteChartDataLocked(chartId: String) {
-        settings.remove("$PREFIX_CHART$chartId")
+        val currentIds = readChartIdsIndexOrThrow().toMutableSet()
+        val updatedIndexJson = if (currentIds.remove(chartId)) {
+            json.encodeToString(currentIds.toList())
+        } else null
 
-        val currentIds = getAllChartIds().toMutableSet()
-        if (currentIds.remove(chartId)) {
-            saveChartIds(currentIds.toList())
+        settings.remove("$PREFIX_CHART$chartId")
+        if (updatedIndexJson != null) {
+            settings.putString(KEY_CHART_IDS, updatedIndexJson)
         }
     }
 

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/RegistryRepository.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/repository/RegistryRepository.kt
@@ -36,14 +36,15 @@ class RegistryRepository(
         entries.forEach { (key, entry) ->
             println("   - $key: ${entry.title} (updatedAt: ${entry.updatedAt})")
         }
-        try {
-            val jsonString = json.encodeToString(entries)
-            println("   JSON size: ${jsonString.length} chars")
-            settings.putString(KEY_REGISTRY_ENTRIES, jsonString)
-            println("   ✅ Saved successfully")
-        } catch (e: SerializationException) {
-            println("   ❌ Error saving registry entries: ${e.message}")
-        }
+        // Why: previously caught SerializationException silently here, which let a
+        // failed save look identical to a successful one. The caller (RegistryManager)
+        // already wraps this in runCatching, so propagating the exception lets it
+        // surface as a refresh failure instead of producing a "succeeded but cache
+        // is empty" state.
+        val jsonString = json.encodeToString(entries)
+        println("   JSON size: ${jsonString.length} chars")
+        settings.putString(KEY_REGISTRY_ENTRIES, jsonString)
+        println("   ✅ Saved successfully")
     }
 
     /**
@@ -81,13 +82,13 @@ class RegistryRepository(
         println("💾 RegistryRepository.saveMetadata()")
         println("   lastDownloadTime: ${metadata.lastDownloadTime}")
         println("   registryVersion: ${metadata.registryVersion}")
-        try {
-            val jsonString = json.encodeToString(metadata)
-            settings.putString(KEY_METADATA, jsonString)
-            println("   ✅ Metadata saved successfully")
-        } catch (e: SerializationException) {
-            println("   ❌ Error saving registry metadata: ${e.message}")
-        }
+        // Why: silent failure here was the most likely explanation for the "Stale"
+        // indicator persisting after a refresh — metadata never lands, so
+        // isRegistryStale() returns true even though entries were just fetched.
+        // Propagate so it surfaces as a refresh failure.
+        val jsonString = json.encodeToString(metadata)
+        settings.putString(KEY_METADATA, jsonString)
+        println("   ✅ Metadata saved successfully")
     }
 
     /**

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
@@ -16,6 +16,7 @@ import com.joebad.fastbreak.data.model.MLBMatchupVisualization
 import com.joebad.fastbreak.data.model.NHLPlayoffBracketVisualization
 import com.joebad.fastbreak.data.model.NCAABracketVisualization
 import com.joebad.fastbreak.data.model.NHLMatchupVisualization
+import com.joebad.fastbreak.data.model.Registry
 import com.joebad.fastbreak.data.model.RegistryEntry
 import com.joebad.fastbreak.data.model.ScatterPlotVisualization
 import com.joebad.fastbreak.data.model.Sport
@@ -426,6 +427,80 @@ class ChartDataSynchronizer(
             tags = vizData.tags,
             sortOrder = vizData.sortOrder
         )
+    }
+
+    /**
+     * Builds a Registry directly from server-supplied [entries], using cached
+     * chart data per entry where available and a placeholder otherwise.
+     *
+     * This bypasses the chart_ids index entirely — the registry shape is
+     * derived from the server's authoritative entry list, so a partial or
+     * inconsistent on-disk index can't make charts disappear from the UI.
+     * Charts whose data hasn't been downloaded yet appear as placeholders;
+     * the UI gates clickability on [SyncProgress.isChartReady], so they show
+     * up disabled with a spinner during sync and become interactive when
+     * their data lands.
+     *
+     * @return Registry with one entry per chart in [entries] (placeholders
+     * included), or null if there are no chart entries.
+     */
+    fun buildRegistryFromEntries(entries: Map<String, RegistryEntry>): Registry? {
+        val chartEntries = entries.filter { (_, entry) -> entry.isChart && !entry.isSystem }
+        if (chartEntries.isEmpty()) return null
+
+        val charts = chartEntries.mapNotNull { (fileKey, entry) ->
+            val chartId = fileKeyToChartId(fileKey)
+            val cached = chartDataRepository.getChartData(chartId)
+            if (cached != null) {
+                buildChartDefinition(chartId, cached)
+            } else {
+                buildPlaceholderChartDefinition(chartId, entry)
+            }
+        }
+
+        if (charts.isEmpty()) return null
+
+        return Registry(
+            version = "2.0",
+            lastUpdated = Clock.System.now(),
+            charts = charts
+        )
+    }
+
+    /**
+     * Builds a minimal ChartDefinition for a chart that's known from the
+     * registry but hasn't been downloaded yet. Returns null if the sport
+     * can't be inferred from the chart id (we won't know which tab to
+     * render it under).
+     *
+     * Sport is inferred from the chart id convention `{sport}__{name}` —
+     * the same convention used by the build pipeline. The placeholder uses
+     * defaults for fields that come from chart data (subtitle, tags,
+     * visualizationType, sortOrder); the UI shows these in a disabled state
+     * via [SyncProgress.isChartReady] until the real data lands.
+     */
+    private fun buildPlaceholderChartDefinition(chartId: String, entry: RegistryEntry): ChartDefinition? {
+        val sport = extractSportFromChartId(chartId) ?: return null
+        return ChartDefinition(
+            id = chartId,
+            sport = sport,
+            title = entry.title,
+            subtitle = "",
+            lastUpdated = entry.updatedAt,
+            visualizationType = VizType.HELLO_WORLD,
+            url = "",
+            interval = entry.interval,
+            cachedAt = null,
+            viewed = true, // suppress unread indicator until real data arrives
+            tags = null,
+            sortOrder = null
+        )
+    }
+
+    private fun extractSportFromChartId(chartId: String): Sport? {
+        val prefix = chartId.substringBefore("__", missingDelimiterValue = "")
+        if (prefix.isEmpty()) return null
+        return Sport.entries.firstOrNull { it.name.equals(prefix, ignoreCase = true) }
     }
 
     /**

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
@@ -360,6 +360,19 @@ class ChartDataSynchronizer(
             chartDataRepository.saveChartData(chartId, cachedData)
             println("✅ Chart $chartId saved to cache")
 
+            // Verify the save actually landed in both the data store AND the index.
+            // Without this, a silent storage failure or index inconsistency leaves the
+            // chart visible to syncedCharts but invisible to buildRegistryFromCache,
+            // which is exactly the "downloads succeed but charts don't show" symptom.
+            // Throwing here routes the failure into the per-chart catch block and onto
+            // failedCharts, so the user sees a toast and Sentry gets the exception.
+            check(chartDataRepository.hasChartData(chartId)) {
+                "Chart data missing from cache after save: $chartId"
+            }
+            check(chartDataRepository.getAllChartIds().contains(chartId)) {
+                "Chart $chartId missing from index after save (index size=${chartDataRepository.getAllChartIds().size})"
+            }
+
             SentryLogger.finishSpan(spanId, SpanStatus.OK)
 
             SentryLogger.addBreadcrumb(

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/HomeScreen.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/HomeScreen.kt
@@ -431,9 +431,15 @@ fun HomeScreen(
                         items(filteredCharts) { chart ->
                             // Determine chart sync state
                             val isSyncing = registryState.syncProgress?.isChartSyncing(chart.id) == true
-                            // If syncProgress is null, all charts are ready (sync complete)
-                            // If syncProgress exists, check if this specific chart is ready
-                            val isReady = registryState.syncProgress?.isChartReady(chart.id) ?: true
+                            // During sync, defer to per-chart progress.
+                            // Outside sync, "ready" means the chart actually has cached data — a
+                            // placeholder whose data never downloaded keeps cachedAt=null and
+                            // stays disabled instead of opening to an empty DataVizScreen.
+                            val isReady = if (registryState.syncProgress != null) {
+                                registryState.syncProgress.isChartReady(chart.id)
+                            } else {
+                                chart.cachedAt != null
+                            }
 
                             VisualizationItem(
                                 title = chart.title,

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/container/RegistryContainer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/container/RegistryContainer.kt
@@ -44,7 +44,7 @@ class RegistryContainer(
             println("   📖 Getting cached registry entries...")
             val cachedEntries = registryManager.getCachedRegistryEntries()
             println("   📖 Building registry from cache...")
-            val registry = buildRegistryFromCache()
+            val registry = buildRegistry(cachedEntries)
             println("   📝 Updating state with cached data")
             println("   - registryEntries: ${cachedEntries?.size ?: 0} entries")
             println("   - registry: ${registry?.charts?.size ?: 0} charts")
@@ -68,54 +68,38 @@ class RegistryContainer(
     }
 
     /**
-     * Builds a Registry object from cached chart data.
-     * Used to reconstruct the registry for UI display after sync.
+     * Builds a Registry for UI display.
+     *
+     * Prefers [entries] (the authoritative server list) when available — every
+     * chart entry produces a Registry.charts item, with cached chart data
+     * folded in where present and a placeholder otherwise. This makes the UI's
+     * chart list a function of "what the server says exists", not "what
+     * happens to be in the on-disk index right now", so a partial cache or
+     * inconsistent index can no longer make charts disappear.
+     *
+     * Falls back to cache-only reconstruction when entries aren't available
+     * (e.g. the init path before any successful refresh).
      */
-    private fun buildRegistryFromCache(): Registry? {
-        println("═══════════════════════════════════════════════════════")
-        println("🔨 BUILD REGISTRY: Starting buildRegistryFromCache()")
-        println("═══════════════════════════════════════════════════════")
+    private fun buildRegistry(entries: Map<String, RegistryEntry>?): Registry? {
+        if (entries != null) {
+            return chartDataSynchronizer.buildRegistryFromEntries(entries)
+        }
 
         val chartIds = chartDataSynchronizer.getCachedChartIds()
-        println("📦 BUILD REGISTRY: Found ${chartIds.size} cached chart ID(s):")
-        chartIds.forEach { println("   - $it") }
-
-        if (chartIds.isEmpty()) {
-            println("⚠️  BUILD REGISTRY: No cached charts found, returning null")
-            println("═══════════════════════════════════════════════════════")
-            return null
-        }
+        if (chartIds.isEmpty()) return null
 
         val charts = chartIds.mapNotNull { chartId ->
-            val cached = chartDataSynchronizer.getCachedChartData(chartId)
-            if (cached == null) {
-                println("   ⚠️ BUILD REGISTRY: No cached data for chart: $chartId")
-                return@mapNotNull null
-            }
-            val chartDef = chartDataSynchronizer.buildChartDefinition(chartId, cached)
-            if (chartDef != null) {
-                println("   ✅ BUILD REGISTRY: Built '${chartDef.title}' (id=${chartDef.id}, type=${chartDef.visualizationType})")
-            } else {
-                println("   ⚠️ BUILD REGISTRY: Failed to build ChartDefinition for: $chartId")
-            }
-            chartDef
+            val cached = chartDataSynchronizer.getCachedChartData(chartId) ?: return@mapNotNull null
+            chartDataSynchronizer.buildChartDefinition(chartId, cached)
         }
 
-        if (charts.isEmpty()) {
-            println("⚠️  BUILD REGISTRY: No valid charts built, returning null")
-            println("═══════════════════════════════════════════════════════")
-            return null
-        }
+        if (charts.isEmpty()) return null
 
-        val registry = Registry(
+        return Registry(
             version = "2.0",
             lastUpdated = Clock.System.now(),
             charts = charts
         )
-        println("✅ BUILD REGISTRY: Complete - built ${registry.charts.size} chart(s):")
-        registry.charts.forEach { println("   - ${it.title} (id=${it.id})") }
-        println("═══════════════════════════════════════════════════════")
-        return registry
     }
 
     // Note: We don't auto-load in init to avoid triggering network requests
@@ -204,9 +188,15 @@ class RegistryContainer(
 
         registryManager.checkAndUpdateRegistry()
             .onSuccess { entries ->
+                // Seed the registry with one entry per server-known chart (placeholders
+                // for ones not yet cached) so the UI can render the full list with
+                // per-chart spinners during sync instead of waiting for buildRegistry
+                // to fire on the final isComplete emit.
+                val seededRegistry = buildRegistry(entries)
                 reduce {
                     state.copy(
                         registryEntries = entries,
+                        registry = seededRegistry,
                         isLoading = false,
                         diagnostics = loadDiagnostics().copy(
                             isSyncing = true  // Keep syncing state active for chart data sync
@@ -290,9 +280,11 @@ class RegistryContainer(
                 if (cachedEntries != null) {
                     println("📦 Falling back to cached registry with ${cachedEntries.size} entries")
 
+                    val seededRegistry = buildRegistry(cachedEntries)
                     reduce {
                         state.copy(
                             registryEntries = cachedEntries,
+                            registry = seededRegistry,
                             isLoading = false,
                             diagnostics = loadDiagnostics().copy(
                                 isSyncing = true,  // Keep syncing state active for chart data sync
@@ -405,9 +397,15 @@ class RegistryContainer(
                 val entries = refreshResult.getOrThrow()
                 println("✅ forceRefreshRegistry() SUCCESS - Received ${entries.size} entries")
 
+                // Seed the registry with one entry per server-known chart (placeholders
+                // for ones not yet cached) so the UI can render the full list with
+                // per-chart spinners during sync instead of waiting for buildRegistry
+                // to fire on the final isComplete emit.
+                val seededRegistry = buildRegistry(entries)
                 reduce {
                     state.copy(
                         registryEntries = entries,
+                        registry = seededRegistry,
                         diagnostics = loadDiagnostics().copy(
                             isSyncing = true  // Keep syncing state active for chart data sync
                         )
@@ -517,9 +515,11 @@ class RegistryContainer(
                 if (cachedEntries != null) {
                     println("📦 Falling back to cached registry with ${cachedEntries.size} entries")
 
+                    val seededRegistry = buildRegistry(cachedEntries)
                     reduce {
                         state.copy(
                             registryEntries = cachedEntries,
+                            registry = seededRegistry,
                             diagnostics = loadDiagnostics().copy(
                                 isSyncing = true,  // Keep syncing state active for chart data sync
                                 failedSyncs = container.stateFlow.value.diagnostics.failedSyncs + 1,
@@ -620,9 +620,9 @@ class RegistryContainer(
             chartDataSynchronizer.synchronizeCharts(entries).collect { progress ->
             // Skip showing progress if nothing needs syncing (everything cached)
             if (progress.total == 0) {
-                // Everything is already cached, build registry from cache
+                // Everything is already cached, build registry from server entries
                 // Keep isSyncing = true - caller will clear after topics sync
-                val registry = buildRegistryFromCache()
+                val registry = buildRegistry(entries)
                 intent {
                     reduce {
                         state.copy(
@@ -637,8 +637,8 @@ class RegistryContainer(
             }
 
             if (progress.isComplete) {
-                // Build registry from cached chart data
-                val registry = buildRegistryFromCache()
+                // Build registry from server entries (cache folded in per entry)
+                val registry = buildRegistry(entries)
 
                 // Capture failed charts before clearing syncProgress
                 val completedFailedCharts = progress.failedCharts

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/diagnostics/RegistryOverviewList.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/diagnostics/RegistryOverviewList.kt
@@ -70,24 +70,33 @@ fun RegistryOverviewList(
 
 /**
  * Single line chart item showing title and last updated time.
+ *
+ * Placeholders (charts that exist in the registry but whose data hasn't
+ * landed in cache yet — cachedAt == null) render disabled so clicking
+ * doesn't open DataVizScreen to a missing-data error.
  */
 @Composable
 private fun ChartOverviewItem(
     chart: ChartDefinition,
     onClick: () -> Unit
 ) {
+    val isReady = chart.cachedAt != null
+    val alpha = if (isReady) 1f else 0.5f
+    val rowModifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(4.dp))
+        .let { if (isReady) it.clickable(onClick = onClick) else it }
+        .padding(vertical = 4.dp, horizontal = 4.dp)
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
-            .clickable(onClick = onClick)
-            .padding(vertical = 4.dp, horizontal = 4.dp)
+        modifier = rowModifier
     ) {
         Text(
             text = chart.title,
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
@@ -99,7 +108,7 @@ private fun ChartOverviewItem(
             text = formatTimeAgo(chart.lastUpdated),
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f * alpha),
             maxLines = 1
         )
     }


### PR DESCRIPTION
## Summary

PR #71 ("loud saves + verification") didn't fix the user-reported symptom: on first install, the first refresh still produces a **different subset of charts each time**, with no error toasts and no `failedCharts` entries. That means either (a) the underlying write race is still happening in a way the post-save verification can't catch, or (b) the on-disk `chart_ids` index temporarily passes verification but later state diverges from it.

Either way, deriving `registry.charts` from the on-disk index is fragile — any inconsistency between the index and the `chart_<id>` data keys silently makes charts vanish from the UI. This PR makes `registry.charts` a function of the **server's authoritative entry list** instead, with placeholders for charts whose data hasn't landed yet. The on-disk index is no longer involved in deciding what the user sees.

## What changed

- **`ChartDataSynchronizer.buildRegistryFromEntries(entries)`** — new public function that builds one `Registry.charts` item per chart entry. If chart data is in cache (looked up directly by `chartId`, bypassing the index) it's used as-is. Otherwise emits a minimal placeholder built from the registry entry (`title`, `interval`, `updatedAt`) with sport inferred from the chart id convention `{sport}__{name}`.
- **`RegistryContainer.buildRegistry`** — replaces `buildRegistryFromCache`. Delegates to the entry-based build when entries are available, falls back to cache-only reconstruction only at init (when no entries have been fetched).
- **Refresh / load paths** — `refreshRegistry`, `loadRegistry`, and both `cachedEntries` fallback paths now seed `registry` immediately after entries arrive (placeholders included), so the list shows up at the start of sync instead of waiting for the final `isComplete` emit.
- **`HomeScreen.kt`** — outside of an active sync, `isReady` now keys off `chart.cachedAt`. A placeholder whose data never landed stays disabled instead of opening `DataVizScreen` to an empty-data error. During sync, defer to `SyncProgress.isChartReady` so per-chart spinners and ready state still come from the synchronizer.
- **`RegistryOverviewList`** (drawer menu) — gates clickability on the same `cachedAt` check for the same reason.

## User-visible effect

- Every chart the server's registry lists shows up the moment entries are fetched, **faded with a spinner while its data downloads**, then **becomes clickable when its data lands**.
- If the underlying write race (whatever it is) drops a chart's data, that chart stays faded instead of disappearing — the failure is visible to the user, and the next refresh re-downloads it because `needsUpdate` already keys off `getChartData(chartId)` (the data key, not the index).

## What this does NOT do

I still couldn't isolate the underlying race from code inspection — the post-save `check()`s from #71 should turn any silent index inconsistency into a failed-chart toast, and the user reports no toasts. So this PR doesn't fix the root race itself; it sidesteps it by making the UI's chart list resilient to index/cache desync. If we ever do catch the underlying cause, the placeholder system is still the right architecture, so this isn't wasted work.

## Test plan

- [ ] Fresh install → first refresh: every chart the registry lists appears in its sport tab from the start, faded, with spinners during download.
- [ ] As individual charts complete, they become clickable; the spinner disappears for that chart.
- [ ] After sync finishes, fully-downloaded charts are clickable; any chart whose data didn't land remains faded and non-clickable.
- [ ] Tapping refresh again on a partially-synced state re-downloads the missing charts.
- [ ] Drawer menu (`RegistryOverviewList`): placeholders render faded and non-clickable; cached charts behave as before.
- [ ] Tag filter: only operates on real (cached) charts since placeholders have no tags. Acceptable since the filter UI is most useful post-sync.

## Notes

- Couldn't run gradle compile from the sandbox (no Google Maven access for the Android plugin). Please verify locally before merging.
- Placeholder sport extraction relies on the `{sport}__{name}` convention. A chart whose id doesn't match a known `Sport` enum value won't render a placeholder, but will still show up once downloaded. Worth noting if you change the chart-naming convention.

https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF)_