### PR TITLE
Isolate per-chart failures with supervisorScope, surface silent drops

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/domain/registry/ChartDataSynchronizer.kt
@@ -34,9 +34,9 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
@@ -159,8 +159,16 @@ class ChartDataSynchronizer(
             send(snapshot)
         }
 
-        // Launch all downloads in parallel with concurrency limit
-        coroutineScope {
+        // Launch all downloads in parallel with concurrency limit.
+        // Why supervisorScope: with coroutineScope, a single child completing
+        // exceptionally (including via CancellationException — e.g. a spurious
+        // cancel) makes `jobs.forEach { it.await() }` rethrow, which then
+        // cancels every other still-running child as cleanup. That cascade
+        // produces "different subset of charts each time" without anything
+        // ending up in failedCharts. supervisorScope isolates each child;
+        // wrapping each await in try-catch keeps the loop alive so we wait
+        // for every chart to settle regardless of how individual ones end.
+        supervisorScope {
             val jobs = chartsNeedingUpdate.map { (fileKey, entry) ->
                 async {
                     val chartId = fileKeyToChartId(fileKey)
@@ -185,6 +193,7 @@ class ChartDataSynchronizer(
                         }
                     } catch (e: CancellationException) {
                         // Propagate cancellation so structured concurrency works
+                        println("⚠️ Chart $chartId cancelled during sync: ${e.message}")
                         throw e
                     } catch (e: Exception) {
                         // Log error but continue with other charts
@@ -209,8 +218,46 @@ class ChartDataSynchronizer(
                 }
             }
 
-            // Wait for all downloads to complete
-            jobs.forEach { it.await() }
+            // Wait for every download to settle. Each await is guarded so a
+            // single chart completing exceptionally (including a stray
+            // CancellationException) can't short-circuit the loop and leave
+            // the other charts unawaited — see the supervisorScope comment
+            // above for why this matters.
+            jobs.forEach { job ->
+                try {
+                    job.await()
+                } catch (e: CancellationException) {
+                    // The per-chart catch already logged this. We just need
+                    // to keep iterating so the remaining charts can settle.
+                    println("⚠️ Job await caught CancellationException (continuing): ${e.message}")
+                } catch (e: Exception) {
+                    // Shouldn't happen — the inner catch (e: Exception) above
+                    // already absorbs non-cancellation exceptions. Log
+                    // defensively in case something slips through.
+                    println("⚠️ Job await caught unexpected exception: ${e::class.simpleName}: ${e.message}")
+                }
+            }
+        }
+
+        // Post-hoc accounting: any chart that was supposed to sync but is in
+        // neither syncedCharts nor failedCharts was silently dropped (e.g.
+        // cancelled before its catch block could record the failure). Record
+        // it so the user sees a toast instead of a stuck gray placeholder,
+        // and the next refresh will re-download it (needsUpdate already keys
+        // off the data key being absent).
+        val expectedChartIds = chartsNeedingUpdate.keys.map { fileKeyToChartId(it) }.toSet()
+        val accountedChartIds = stateMutex.withLock {
+            syncedCharts + failedCharts.map { it.first }
+        }
+        val droppedChartIds = expectedChartIds - accountedChartIds
+        if (droppedChartIds.isNotEmpty()) {
+            println("⚠️ ${droppedChartIds.size} chart(s) silently dropped (no save, no error):")
+            droppedChartIds.forEach { println("   - $it") }
+            stateMutex.withLock {
+                droppedChartIds.forEach { chartId ->
+                    failedCharts.add(chartId to "Silently dropped — coroutine ended without saving")
+                }
+            }
         }
 
         println("✅ All chart downloads complete")

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/container/RegistryContainer.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/container/RegistryContainer.kt
@@ -636,10 +636,15 @@ class RegistryContainer(
                 return@collect
             }
 
-            if (progress.isComplete) {
-                // Build registry from server entries (cache folded in per entry)
-                val registry = buildRegistry(entries)
+            // Rebuild registry on every emit so each chart's completion
+            // immediately propagates to the UI (placeholder → real data),
+            // instead of waiting for the final isComplete to surface the
+            // batch. buildRegistry just iterates entries with a per-chart
+            // cache lookup — cheap enough to do per-emit, and keeps the UI
+            // in sync with whatever's actually landed on disk.
+            val registry = buildRegistry(entries)
 
+            if (progress.isComplete) {
                 // Capture failed charts before clearing syncProgress
                 val completedFailedCharts = progress.failedCharts
 
@@ -666,10 +671,13 @@ class RegistryContainer(
                     postSideEffect(RegistrySideEffect.SyncCompleted)
                 }.join()
             } else {
-                // Normal progress update
+                // Normal progress update — also fold in the freshly-rebuilt
+                // registry so newly-cached charts become clickable without
+                // waiting for the final emit.
                 intent {
                     reduce {
                         state.copy(
+                            registry = registry,
                             syncProgress = progress,
                             isSyncing = true
                         )


### PR DESCRIPTION
## Summary

After #72 shipped the placeholder rendering, you could see charts staying gray even though the registry knew they existed. That narrowed the root cause to exactly one path: per-chart async coroutines that exit via the `catch (e: CancellationException) { throw e }` rethrow. The `finally` block still increments `completedCount`, but the chart lands in **neither** `syncedCharts` nor `failedCharts` — no toast, no error, just a stuck gray placeholder.

Two ways that happens, both addressed here.

## Root cause #1: `coroutineScope` cascade

`coroutineScope { jobs.forEach { it.await() } }` is sensitive to *any* child exiting exceptionally — including a `CancellationException` from one chart. The moment the first `await()` rethrows, `coroutineScope`'s body has thrown, so it cancels every other still-running child as cleanup. Those siblings die mid-download with no entry anywhere.

The surviving set is whichever charts happened to finish before the first cancellation — which is exactly why the user sees a **different subset every run**.

**Fix:** switch to `supervisorScope` (child cancellations don't cascade) and wrap each `job.await()` in try-catch so a single `CancellationException` can't short-circuit the await loop. Every chart gets to settle regardless of how individual ones end.

## Root cause #2: cancelled charts still vanish

Even with the cascade fixed, a chart that's genuinely cancelled (whatever the source) still re-throws from its catch, increments via `finally`, and ends up tracked nowhere.

**Fix:** after the `supervisorScope` returns, sweep `chartsNeedingUpdate` against `syncedCharts ∪ failedCharts` and add anything missing to `failedCharts` as `"Silently dropped — coroutine ended without saving"`. The user now sees a toast, and the existing `needsUpdate` logic already keys off the data key (not the index), so the next refresh will re-download those charts.

## Per-chart UI updates

`RegistryContainer.syncChartData` previously only rebuilt `registry` on `isComplete`. Now it rebuilds on every progress emit so each chart's completion immediately flips its UI item from placeholder → clickable real data, instead of the whole batch landing at the end. `buildRegistry` just iterates entries with a per-chart cache lookup — cheap enough to do per-emit.

## Diagnostic logging

Added `println` on the cancellation paths so the next repro will show in console which chart was cancelled and at which `await` stage. If charts *are* still being cancelled (rather than the cascade being the whole story), the logs will tell us where the cancellation originated.

## Test plan

- [ ] Fresh install → first refresh: all charts should now eventually become clickable (no permanent gray placeholders).
- [ ] If any chart genuinely fails to sync, you should see a failure toast — no more silent drops.
- [ ] Per-chart UI updates: as each chart completes, it should flip from placeholder to clickable without waiting for the full batch.
- [ ] If a chart fails on first refresh, a second refresh should re-download just the missing ones (`needsUpdate` semantics unchanged).
- [ ] Check console for any `⚠️ Chart $chartId cancelled during sync` or `⚠️ N chart(s) silently dropped` messages — those tell us if charts are still being cancelled at runtime.

## Notes

- Could not run gradle compile from sandbox (no Google Maven access). Please run a local build before un-drafting.
- If the diagnostic logs show charts are still being cancelled even with `supervisorScope`, we'll know the cancellation source is upstream (the channelFlow itself, or the orbit intent) and that's the next thread to pull on.

https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01THzkvjxwR4muFitx8z8zGF)_