### PR TITLE
Fix iOS TestFlight builds shipping dev_mode=true

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,4 +284,14 @@ jobs:
           VERSION_NAME: ${{ steps.build_info.outputs.version_name }}
           BUILD_NUMBER: ${{ steps.build_info.outputs.build_number }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # fastlane's build_app triggers xcodebuild, whose "Compile Kotlin
+          # Framework" build phase runs ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+          # with no -P flags. That regenerates AppConfig.kt from gradle.properties
+          # defaults (dev_mode=true), overwriting the framework built earlier.
+          # Pass the values via ORG_GRADLE_PROJECT_* so that in-Xcode Gradle run
+          # picks them up and produces a prod (dev_mode=false) framework.
+          ORG_GRADLE_PROJECT_dev_mode: "false"
+          ORG_GRADLE_PROJECT_built_in_release_id: ${{ steps.release_id.outputs.release_id }}
+          ORG_GRADLE_PROJECT_otel_endpoint: ${{ secrets.OTEL_ENDPOINT }}
+          ORG_GRADLE_PROJECT_otel_auth_token: ${{ secrets.OTEL_AUTH_TOKEN }}
         run: bundle exec fastlane ios beta


### PR DESCRIPTION
## Problem

iOS builds installed from TestFlight still ran in **registry dev** mode (`dev_mode=true`), even though the deploy workflow passed `-Pdev_mode=false`.

## Root cause

The iOS deploy job pre-builds the KMP framework with `-Pdev_mode=false`:

```
./gradlew :shared:linkReleaseFrameworkIosArm64 ... -Pdev_mode=false
```

But fastlane's `build_app` (`kmp/iosApp/fastlane/Fastfile:46`) runs `xcodebuild`, and the Xcode project has a "Compile Kotlin Framework" build phase (`kmp/iosApp/iosApp.xcodeproj/project.pbxproj:278`):

```
cd "$SRCROOT/.."
./gradlew :shared:embedAndSignAppleFrameworkForXcode
```

This Gradle invocation runs with **no `-P` flags**, so `generateAppConfig` (`kmp/shared/build.gradle.kts:14`) falls back to the `gradle.properties` default `dev_mode=true`, regenerates `AppConfig.kt` with `DEV_MODE = true`, and re-links the framework that actually ships in the `.ipa`. The earlier prod framework gets overwritten.

## Fix

Gradle reads project properties from `ORG_GRADLE_PROJECT_*` env vars. Setting them on the `Deploy to TestFlight` step means the in-Xcode Gradle run picks up `dev_mode=false` (plus release id and otel config), producing a prod framework. Env vars are inherited by the `xcodebuild` → build-phase child process.

The Android job is unaffected — it builds in a single `bundleRelease` Gradle invocation with `-Pdev_mode=false` and never re-links via Xcode.

## Test plan

- [ ] Run the Deploy workflow; confirm the `embedAndSignAppleFrameworkForXcode` build-phase log shows `DEV_MODE: Boolean = false` in the generated `AppConfig.kt`.
- [ ] Install the resulting TestFlight build; confirm the settings menu shows **registry prod** (not dev).

https://claude.ai/code/session_01Xi2vp7FG3wbtWDnfCaFtFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi2vp7FG3wbtWDnfCaFtFd)_