### PR TITLE
Bump kmp deploy trigger comment

### DIFF
--- a/kmp/shared/build.gradle.kts
+++ b/kmp/shared/build.gradle.kts
@@ -1,4 +1,4 @@
-// Deploy trigger: 2026-05-19-v5 - Build offset 1000
+// Deploy trigger: 2026-05-21-v6 - Build offset 1000
 import java.io.File
 
 plugins {


### PR DESCRIPTION
## Summary

- Bumps the deploy-trigger comment in `kmp/shared/build.gradle.kts` (`v5` → `v6`) to trigger a build.

https://claude.ai/code/session_01Xi2vp7FG3wbtWDnfCaFtFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi2vp7FG3wbtWDnfCaFtFd)_