### PR TITLE
Add last-10-games ledger to MLB team report card (pipeline + web + KMP)

### DIFF
--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/model/VisualizationTypes.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/data/model/VisualizationTypes.kt
@@ -1287,6 +1287,33 @@ data class ReportCardCategories(
 )
 
 @Serializable
+data class ReportCardGameLogGame(
+    val date: String? = null,
+    val location: String,          // "vs" (home) or "@" (away)
+    val opponent: String,
+    val opponentLabel: String,     // e.g. "vs LAD" or "@ SF"
+    val teamScore: Int,
+    val opponentScore: Int,
+    val differential: Int,
+    val won: Boolean
+)
+
+@Serializable
+data class ReportCardGameLogRecord(
+    val wins: Int = 0,
+    val losses: Int = 0,
+    val display: String = "0-0"
+)
+
+@Serializable
+data class ReportCardLastTenGames(
+    val label: String = "Last 10 Games",
+    val columns: List<String> = emptyList(),
+    val games: List<ReportCardGameLogGame> = emptyList(),
+    val record: ReportCardGameLogRecord? = null
+)
+
+@Serializable
 data class ReportCardTeam(
     val teamCode: String,
     val teamName: String,
@@ -1302,6 +1329,7 @@ data class ReportCardTeam(
     val overallCompositeRank: Int? = null,
     val overallCompositeRankDisplay: String? = null,
     val playoffProb: Double? = null,
+    val lastTenGames: ReportCardLastTenGames? = null,
     val categories: ReportCardCategories
 )
 

--- a/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/MLBTeamReportCardWorksheet.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/joebad/fastbreak/ui/visualizations/MLBTeamReportCardWorksheet.kt
@@ -38,6 +38,8 @@ import com.joebad.fastbreak.data.model.PinnedTeam
 import com.joebad.fastbreak.data.model.PlayoffChanceEntry
 import com.joebad.fastbreak.data.model.RankingEntry
 import com.joebad.fastbreak.data.model.ReportCardCategory
+import com.joebad.fastbreak.data.model.ReportCardGameLogGame
+import com.joebad.fastbreak.data.model.ReportCardLastTenGames
 import com.joebad.fastbreak.data.model.ReportCardPlayer
 import com.joebad.fastbreak.data.model.ReportCardStatValue
 import com.joebad.fastbreak.data.model.ReportCardTeam
@@ -289,6 +291,7 @@ private fun mergeReportCardRankings(
 
 private enum class ReportCardShareTarget(val categoryKey: String?, val shareLabel: String) {
     RECENT_TREND("recentTrend", "4 Week Trend"),
+    LAST_TEN(null, "Last 10 Games"),
     HITTERS("hitters", "Hitters"),
     STARTERS("starters", "Starting Pitchers"),
     RELIEVERS("relievers", "Bullpen"),
@@ -590,6 +593,13 @@ fun MLBTeamReportCardWorksheet(
                     .verticalScroll(rememberScrollState())
                     .padding(top = 8.dp, bottom = 80.dp)
             ) {
+                selectedTeam.lastTenGames
+                    ?.takeIf { it.games.isNotEmpty() }
+                    ?.let { lastTen ->
+                        ReportCardLastTenGamesSection(lastTen)
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
+
                 categories.forEachIndexed { index, (key, category) ->
                     val config = CATEGORY_CONFIGS[key] ?: return@forEachIndexed
                     val hasTeamStats = !category.team?.stats.isNullOrEmpty()
@@ -631,18 +641,21 @@ fun MLBTeamReportCardWorksheet(
         }
 
         if (selectedTeam != null) {
-            val shareOptions = ReportCardShareTarget.entries.map { target ->
-                FabOption(
-                    icon = Icons.Filled.Share,
-                    label = target.shareLabel,
-                    onClick = {
-                        captureRequest = ReportCardCaptureRequest(
-                            target = target,
-                            title = "${selectedTeam.teamCode} Report Card - ${target.shareLabel}"
-                        )
-                    }
-                )
-            }
+            val hasLastTen = !selectedTeam.lastTenGames?.games.isNullOrEmpty()
+            val shareOptions = ReportCardShareTarget.entries
+                .filter { it != ReportCardShareTarget.LAST_TEN || hasLastTen }
+                .map { target ->
+                    FabOption(
+                        icon = Icons.Filled.Share,
+                        label = target.shareLabel,
+                        onClick = {
+                            captureRequest = ReportCardCaptureRequest(
+                                target = target,
+                                title = "${selectedTeam.teamCode} Report Card - ${target.shareLabel}"
+                            )
+                        }
+                    )
+                }
             MultiOptionFab(
                 options = shareOptions,
                 modifier = Modifier
@@ -678,7 +691,6 @@ fun MLBTeamReportCardWorksheet(
 
         captureRequest?.let { request ->
             val team = selectedTeam ?: return@let
-            val categoriesToShare = teamShareCategoryEntries(team, request.target)
 
             LaunchedEffect(request) {
                 kotlinx.coroutines.delay(50)
@@ -704,16 +716,24 @@ fun MLBTeamReportCardWorksheet(
                             drawLayer(graphicsLayer)
                         }
                 ) {
-                    MLBTeamReportCardShareImage(
-                        team = team,
-                        seasonLabel = seasonLabel,
-                        source = buildReportCardShareSourceAttribution(
-                            visualization,
-                            request.target.categoryKey
-                        ),
-                        categories = categoriesToShare,
-                        showSummary = request.target.categoryKey == null
-                    )
+                    if (request.target == ReportCardShareTarget.LAST_TEN) {
+                        MLBTeamReportCardLastTenShareImage(
+                            team = team,
+                            seasonLabel = seasonLabel,
+                            source = buildReportCardLastTenShareSource(visualization)
+                        )
+                    } else {
+                        MLBTeamReportCardShareImage(
+                            team = team,
+                            seasonLabel = seasonLabel,
+                            source = buildReportCardShareSourceAttribution(
+                                visualization,
+                                request.target.categoryKey
+                            ),
+                            categories = teamShareCategoryEntries(team, request.target),
+                            showSummary = request.target.categoryKey == null
+                        )
+                    }
                 }
             }
         }
@@ -1626,6 +1646,248 @@ private fun MLBTeamReportCardShareImage(
                 showTeamComposite = config.showTeamComposite,
                 expandStatsForShare = true
             )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = source,
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 9.sp,
+                color = onBg,
+                modifier = Modifier.weight(1f, fill = false)
+            )
+            Text(
+                text = "fbrk.app",
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Bold,
+                color = onBg
+            )
+        }
+    }
+}
+
+// ============================================================================
+// Last 10 games section
+// ============================================================================
+private val LAST_TEN_SCORE_WIDTH = 46.dp
+private val LAST_TEN_DIFF_WIDTH = 52.dp
+private val LAST_TEN_ROW_MIN_HEIGHT = 22.dp
+private val LAST_TEN_OPP_MIN_WIDTH = 84.dp
+private val LAST_TEN_WIN_COLOR = Color(0xFF228B22)
+private val LAST_TEN_LOSS_COLOR = Color(0xFFC0392B)
+private val SHARE_LAST_TEN_MIN_WIDTH = 260.dp
+
+private fun formatLastTenDifferential(diff: Int): String =
+    if (diff > 0) "+$diff" else diff.toString()
+
+@Composable
+private fun LastTenGamesRow(
+    opponent: @Composable () -> Unit,
+    oppScore: @Composable () -> Unit,
+    teamScore: @Composable () -> Unit,
+    diff: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = LAST_TEN_ROW_MIN_HEIGHT)
+            .padding(vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .widthIn(min = LAST_TEN_OPP_MIN_WIDTH)
+                .padding(start = 4.dp, end = 4.dp),
+            contentAlignment = Alignment.CenterStart
+        ) { opponent() }
+        Box(modifier = Modifier.width(LAST_TEN_SCORE_WIDTH), contentAlignment = Alignment.CenterEnd) { oppScore() }
+        Box(modifier = Modifier.width(LAST_TEN_SCORE_WIDTH), contentAlignment = Alignment.CenterEnd) { teamScore() }
+        Box(modifier = Modifier.width(LAST_TEN_DIFF_WIDTH), contentAlignment = Alignment.CenterEnd) { diff() }
+    }
+}
+
+@Composable
+private fun LastTenOpponentCell(game: ReportCardGameLogGame) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = game.location,
+            style = MaterialTheme.typography.bodySmall,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            softWrap = false
+        )
+        Spacer(modifier = Modifier.width(3.dp))
+        Text(
+            text = game.opponent,
+            style = MaterialTheme.typography.bodySmall,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun ReportCardLastTenGamesSection(
+    lastTen: ReportCardLastTenGames,
+    modifier: Modifier = Modifier
+) {
+    val games = lastTen.games
+    if (games.isEmpty()) return
+
+    val headerStyle = MaterialTheme.typography.labelSmall
+    val headerColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        SectionHeader(lastTen.label)
+
+        LastTenGamesRow(
+            opponent = { ReportCardHeaderText("Opponent", headerStyle, headerColor, TextAlign.Start) },
+            oppScore = { ReportCardHeaderText("Opp", headerStyle, headerColor, TextAlign.End) },
+            teamScore = { ReportCardHeaderText("Team", headerStyle, headerColor, TextAlign.End) },
+            diff = { ReportCardHeaderText("Diff", headerStyle, headerColor, TextAlign.End) }
+        )
+
+        games.forEach { game ->
+            LastTenGamesRow(
+                opponent = { LastTenOpponentCell(game) },
+                oppScore = { ReportCardStatText(game.opponentScore.toString(), TextAlign.End) },
+                teamScore = { ReportCardStatText(game.teamScore.toString(), TextAlign.End) },
+                diff = {
+                    Text(
+                        text = formatLastTenDifferential(game.differential),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        softWrap = false,
+                        textAlign = TextAlign.End,
+                        color = if (game.won) LAST_TEN_WIN_COLOR else LAST_TEN_LOSS_COLOR,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(6.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Record (last ${games.size})",
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 10.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = lastTen.record?.display
+                    ?: "${lastTen.record?.wins ?: 0}-${lastTen.record?.losses ?: 0}",
+                style = MaterialTheme.typography.bodySmall,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+private fun buildReportCardLastTenShareSource(
+    visualization: MLBTeamReportCardVisualization
+): String {
+    val sources = parseReportCardSources(visualization.source ?: "MLB Stats API")
+        .filter { it.contains("MLB", ignoreCase = true) && it.contains("Stats", ignoreCase = true) }
+        .distinct()
+    return sources.joinToString(" • ").ifBlank { "MLB Stats API" }
+}
+
+@Composable
+private fun rememberLastTenShareImageWidth(
+    team: ReportCardTeam,
+    seasonLabel: String,
+    source: String
+): Dp {
+    val density = LocalDensity.current
+    val textMeasurer = rememberTextMeasurer()
+    val titleStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+    val sourceStyle = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp)
+    val subtitleLine = formatReportCardShareSubtitleLine(seasonLabel, team)
+
+    val subtitleWidth = with(density) {
+        textMeasurer.measure(text = subtitleLine, style = titleStyle, softWrap = false, maxLines = 1).size.width.toDp()
+    }
+    val teamNameWidth = with(density) {
+        textMeasurer.measure(text = team.teamName, style = titleStyle, softWrap = false, maxLines = 1).size.width.toDp()
+    }
+    val sourceWidth = with(density) {
+        textMeasurer.measure(text = source, style = sourceStyle, softWrap = false, maxLines = 1).size.width.toDp()
+    }
+    val tableWidth = LAST_TEN_OPP_MIN_WIDTH + LAST_TEN_SCORE_WIDTH * 2 + LAST_TEN_DIFF_WIDTH + 8.dp
+
+    return remember(team, seasonLabel, source, subtitleWidth, teamNameWidth, sourceWidth) {
+        listOf(
+            tableWidth + SHARE_REPORT_CARD_HORIZONTAL_PADDING,
+            subtitleWidth + SHARE_REPORT_CARD_HORIZONTAL_PADDING,
+            teamNameWidth + SHARE_REPORT_CARD_HORIZONTAL_PADDING,
+            sourceWidth + 72.dp + SHARE_REPORT_CARD_HORIZONTAL_PADDING
+        ).max().coerceAtLeast(SHARE_LAST_TEN_MIN_WIDTH)
+    }
+}
+
+@Composable
+private fun MLBTeamReportCardLastTenShareImage(
+    team: ReportCardTeam,
+    seasonLabel: String,
+    source: String
+) {
+    val bg = MaterialTheme.colorScheme.background
+    val onBg = MaterialTheme.colorScheme.onSurface
+    val lastTen = team.lastTenGames
+    val shareWidth = rememberLastTenShareImageWidth(team, seasonLabel, source)
+
+    Column(
+        modifier = Modifier
+            .width(shareWidth)
+            .wrapContentHeight()
+            .background(bg)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = team.teamName,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = onBg,
+            maxLines = 1,
+            softWrap = false
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = formatReportCardShareSubtitleLine(seasonLabel, team),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = onBg,
+            maxLines = 1,
+            softWrap = false
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+        if (lastTen != null) {
+            ReportCardLastTenGamesSection(lastTen)
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/pipeline/04-fastbreak-charts/daily/mlb__team_report_card.R
+++ b/pipeline/04-fastbreak-charts/daily/mlb__team_report_card.R
@@ -1303,6 +1303,134 @@ build_trend_rankings <- function(trend_df) {
   )
 }
 
+# ============================================================================
+# Last 10 games (MLB Stats API completed games)
+# ============================================================================
+LAST_TEN_COUNT <- 10
+# Wide enough to guarantee 10 completed games survive off days and the All-Star
+# break; per-team we sort by game time and keep only the most recent LAST_TEN_COUNT.
+LAST_TEN_WINDOW_DAYS <- 30
+
+# Reuse the hydrated schedule endpoint the 4-week trend rides on, but keep the
+# opponent, home/away flag, and game time so each row is a real game-log entry
+# rather than an aggregate. One request covers the whole window.
+fetch_last_ten_games_raw <- function(start_date, end_date) {
+  cat("Fetching MLB Stats API completed games for last-10 game logs...\n")
+  data <- statsapi_get(paste0(
+    "/schedule?sportId=1&gameType=R",
+    "&startDate=", format(start_date, "%Y-%m-%d"),
+    "&endDate=", format(end_date, "%Y-%m-%d"),
+    "&hydrate=linescore"
+  ))
+  if (is.null(data) || is.null(data$dates)) {
+    cat("Warning: Could not fetch MLB schedule for last-10 game logs\n")
+    return(list())
+  }
+
+  rows <- list()
+  for (day in data$dates) {
+    if (is.null(day$games)) next
+    for (g in day$games) {
+      # Only "F" means played to completion; postponed games report an abstract
+      # "Final" but carry no linescore (see fetch_recent_trend_games).
+      if (!identical(g$status$codedGameState, "F")) next
+
+      ls_teams <- g$linescore$teams
+      if (is.null(ls_teams)) next
+      home_runs <- safe_num(ls_teams$home$runs)
+      away_runs <- safe_num(ls_teams$away$runs)
+      if (is.na(home_runs) || is.na(away_runs)) next
+
+      home_code <- statsapi_team_code(g$teams$home$team$id)
+      away_code <- statsapi_team_code(g$teams$away$team$id)
+      if (is.na(home_code) || is.na(away_code)) next
+
+      # gameDate is an ISO timestamp, so string ordering is chronological and
+      # doubleheaders on the same day stay in the order they were played.
+      game_date <- if (!is.null(g$gameDate)) as.character(g$gameDate[[1]]) else NA_character_
+
+      rows[[length(rows) + 1]] <- list(
+        team_code = home_code,
+        opponent_code = away_code,
+        is_home = TRUE,
+        team_score = home_runs,
+        opponent_score = away_runs,
+        won = home_runs > away_runs,
+        game_date = game_date
+      )
+      rows[[length(rows) + 1]] <- list(
+        team_code = away_code,
+        opponent_code = home_code,
+        is_home = FALSE,
+        team_score = away_runs,
+        opponent_score = home_runs,
+        won = away_runs > home_runs,
+        game_date = game_date
+      )
+    }
+  }
+  rows
+}
+
+# Per-team game log: the most recent LAST_TEN_COUNT games in chronological order,
+# each with a "vs"/"@" opponent label, both scores, and the differential, plus
+# the team's record over exactly those games.
+build_last_ten_for_team <- function(rows, team) {
+  empty <- list(
+    label = "Last 10 Games",
+    columns = list("Opponent", "Opp", "Team", "Diff"),
+    games = list(),
+    record = list(wins = 0L, losses = 0L, display = "0-0")
+  )
+
+  team_rows <- Filter(function(r) identical(r$team_code, team), rows)
+  if (length(team_rows) == 0) return(empty)
+
+  dates <- vapply(team_rows, function(r) r$game_date %||% "", character(1))
+  team_rows <- team_rows[order(dates)]
+  n <- length(team_rows)
+  if (n > LAST_TEN_COUNT) {
+    team_rows <- team_rows[(n - LAST_TEN_COUNT + 1):n]
+  }
+
+  games <- lapply(team_rows, function(r) {
+    diff <- r$team_score - r$opponent_score
+    loc <- if (isTRUE(r$is_home)) "vs" else "@"
+    list(
+      date = if (!is.null(r$game_date) && !is.na(r$game_date) && nzchar(r$game_date)) {
+        substr(r$game_date, 1, 10)
+      } else {
+        NULL
+      },
+      location = loc,
+      opponent = r$opponent_code,
+      opponentLabel = paste(loc, r$opponent_code),
+      teamScore = as.integer(r$team_score),
+      opponentScore = as.integer(r$opponent_score),
+      differential = as.integer(diff),
+      won = isTRUE(r$won)
+    )
+  })
+
+  wins <- sum(vapply(team_rows, function(r) isTRUE(r$won), logical(1)))
+  losses <- length(team_rows) - wins
+  list(
+    label = "Last 10 Games",
+    columns = list("Opponent", "Opp", "Team", "Diff"),
+    games = games,
+    record = list(
+      wins = as.integer(wins),
+      losses = as.integer(losses),
+      display = paste0(wins, "-", losses)
+    )
+  )
+}
+
+last_ten_end <- Sys.Date() - 1
+last_ten_start <- last_ten_end - LAST_TEN_WINDOW_DAYS + 1
+last_ten_games_raw <- fetch_last_ten_games_raw(last_ten_start, last_ten_end)
+cat("Fetched", length(last_ten_games_raw), "team-game entries for last-10 game logs\n")
+
 fielders <- fielder_stats %>%
   mutate(
     team_code = vapply(team_name_abb, normalize_team, character(1)),
@@ -1593,6 +1721,7 @@ teams_json <- lapply(ALL_TEAMS, function(team) {
     below_replacement, team,
     c("PA", "wRC_plus"), below_replacement_labels, below_replacement_digits
   )
+  last_ten <- build_last_ten_for_team(last_ten_games_raw, team)
 
   record_row <- team_records %>% filter(team_code == team)
   overall_row <- team_overall %>% filter(team_code == team)
@@ -1624,6 +1753,7 @@ teams_json <- lapply(ALL_TEAMS, function(team) {
     overallCompositeRank = team_overall_rank,
     overallCompositeRankDisplay = team_overall_rank_display,
     playoffProb = team_playoff_prob,
+    lastTenGames = last_ten,
     categories = list(
       recentTrend = list(
         label = "4 Week Trend",
@@ -1837,7 +1967,11 @@ output_data <- list(
     "rank 1 = fewest below-replacement plate appearances.\n\n",
     " • 4 Week Trend: Recent team performance from MLB Stats API completed games ",
     "over the last 4 weeks. Includes record, run differential per game, ",
-    "runs scored/allowed per game, hits per game, and home runs per game."
+    "runs scored/allowed per game, hits per game, and home runs per game.\n\n",
+    " • Last 10 Games: The team's most recent 10 completed games from the MLB ",
+    "Stats API, in chronological order. Each row shows the opponent (vs = home, ",
+    "@ = away), the opponent's score, the team's score, and the run differential, ",
+    "with the team's record over those 10 games."
   ),
   lastUpdated = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
   source = "FanGraphs • MLB Stats API • ESPN",
@@ -1871,6 +2005,18 @@ if ("Konnor Griffin" %in% pit_names) {
 }
 cat("Teams with data:", sum(vapply(teams_json, function(t) {
   any(vapply(t$categories, function(c) length(c$players) > 0, logical(1)))
+}, logical(1))), "/", length(teams_json), "\n")
+
+lad_last_ten <- output_data$teams$LAD$lastTenGames
+cat("Sample — LAD last 10 record:", lad_last_ten$record$display,
+    "| games:", length(lad_last_ten$games), "\n")
+if (length(lad_last_ten$games) > 0) {
+  g1 <- lad_last_ten$games[[length(lad_last_ten$games)]]
+  cat("  Most recent:", g1$opponentLabel, "-", g1$teamScore, "to", g1$opponentScore,
+      "(diff", g1$differential, ")\n")
+}
+cat("Teams with last-10 data:", sum(vapply(teams_json, function(t) {
+  length(t$lastTenGames$games) > 0
 }, logical(1))), "/", length(teams_json), "\n")
 
 # ============================================================================

--- a/web/src/components/charts/MLBTeamReportCard.tsx
+++ b/web/src/components/charts/MLBTeamReportCard.tsx
@@ -4,6 +4,7 @@ import { Children, isValidElement, useEffect, useLayoutEffect, useMemo, useState
 import {
   MLBTeamReportCardData,
   ReportCardCategory,
+  ReportCardLastTenGames,
   ReportCardPlayer,
   ReportCardStatValue,
   ReportCardTeam,
@@ -362,6 +363,67 @@ function TeamStatRow({ stat, onClick }: { stat?: ReportCardStatValue; onClick?: 
   );
 }
 
+function formatGameDifferential(diff: number): string {
+  return diff > 0 ? `+${diff}` : String(diff);
+}
+
+function LastTenGamesPanel({ lastTen }: { lastTen: ReportCardLastTenGames }) {
+  const games = lastTen.games ?? [];
+  if (games.length === 0) return null;
+
+  const record = lastTen.record;
+  const recordDisplay = record?.display ?? `${record?.wins ?? 0}-${record?.losses ?? 0}`;
+
+  return (
+    <div className="border border-[var(--border)] rounded bg-[var(--card)] w-full max-w-full min-w-0 box-border">
+      <div className="grid grid-cols-[1fr_minmax(60px,1fr)_1fr] gap-0 px-2 py-1 border-b border-[var(--border)] bg-[var(--border)]/30 items-center">
+        <div />
+        <div className="text-center text-xs font-bold whitespace-nowrap">{lastTen.label}</div>
+        <div />
+      </div>
+
+      <div className="min-w-0 max-w-full overflow-x-auto overscroll-x-contain">
+        <table className="w-full min-w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-[var(--border)] bg-[var(--card)] text-xs font-bold">
+              <th className="py-1 pl-2 pr-1 text-left whitespace-nowrap">Opponent</th>
+              <th className="py-1 px-2 text-right whitespace-nowrap">Opp</th>
+              <th className="py-1 px-2 text-right whitespace-nowrap">Team</th>
+              <th className="py-1 pl-2 pr-2 text-right whitespace-nowrap">Diff</th>
+            </tr>
+          </thead>
+          <tbody>
+            {games.map((game, index) => (
+              <tr
+                key={`${game.date ?? ''}-${game.opponent}-${index}`}
+                className="border-b border-[var(--border)] last:border-b-0 hover:bg-[var(--foreground)]/5"
+              >
+                <td className="py-1 pl-2 pr-1 font-medium whitespace-nowrap">
+                  <span className="text-[var(--muted)]">{game.location}</span> {game.opponent}
+                </td>
+                <td className="py-1 px-2 text-right font-mono whitespace-nowrap">{game.opponentScore}</td>
+                <td className="py-1 px-2 text-right font-mono whitespace-nowrap">{game.teamScore}</td>
+                <td
+                  className={`py-1 pl-2 pr-2 text-right font-mono whitespace-nowrap ${
+                    game.won ? 'text-green-500' : 'text-red-500'
+                  }`}
+                >
+                  {formatGameDifferential(game.differential)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto] gap-2 px-2 py-1 border-t border-[var(--border)] items-center text-xs">
+        <span className="text-[var(--muted)] whitespace-nowrap">Record (last {games.length})</span>
+        <span className="font-mono font-medium">{recordDisplay}</span>
+      </div>
+    </div>
+  );
+}
+
 function PlayerTable({
   players,
   statKeys,
@@ -657,7 +719,11 @@ export function MLBTeamReportCard({ data }: Props) {
 
       <div className="flex-1 min-h-0 w-full max-w-full overflow-y-auto overflow-x-hidden">
         <TwoColumnMasonry className="pb-8">
-          {CATEGORY_KEYS.flatMap(key => {
+          {[
+            ...(team.lastTenGames && team.lastTenGames.games.length > 0
+              ? [<LastTenGamesPanel key="lastTenGames" lastTen={team.lastTenGames} />]
+              : []),
+            ...CATEGORY_KEYS.flatMap(key => {
             const category =
               key === 'recentTrend'
                 ? team.categories.recentTrend
@@ -681,7 +747,8 @@ export function MLBTeamReportCard({ data }: Props) {
                 onRankingClick={setRankingSheetKey}
               />,
             ];
-          })}
+            }),
+          ]}
         </TwoColumnMasonry>
       </div>
       </div>

--- a/web/src/types/chart.ts
+++ b/web/src/types/chart.ts
@@ -590,6 +590,30 @@ export interface ReportCardCategories {
   injuries?: ReportCardCategory;
 }
 
+export interface ReportCardGameLogGame {
+  date?: string | null;
+  location: string; // "vs" (home) or "@" (away)
+  opponent: string;
+  opponentLabel: string; // e.g. "vs LAD" or "@ SF"
+  teamScore: number;
+  opponentScore: number;
+  differential: number;
+  won: boolean;
+}
+
+export interface ReportCardGameLogRecord {
+  wins: number;
+  losses: number;
+  display: string; // e.g. "6-4"
+}
+
+export interface ReportCardLastTenGames {
+  label: string;
+  columns?: string[];
+  games: ReportCardGameLogGame[];
+  record: ReportCardGameLogRecord;
+}
+
 export interface ReportCardTeam {
   teamCode: string;
   teamName: string;
@@ -605,6 +629,7 @@ export interface ReportCardTeam {
   overallCompositeRank?: number;
   overallCompositeRankDisplay?: string;
   playoffProb?: number;
+  lastTenGames?: ReportCardLastTenGames;
   categories: ReportCardCategories;
 }
 


### PR DESCRIPTION
## Summary

Adds a per-team **Last 10 Games** ledger to the MLB team report card, end to end: the pipeline script emits the data, and both the web and KMP clients render it. KMP also gains a share option to export the ledger as an image.

Each game row has the four requested columns — **Opponent** (`vs`/`@` + code), **Opp** score, **Team** score, **Diff** (run differential) — with the team's **record** over those games at the bottom.

## Pipeline (`pipeline/04-fastbreak-charts/daily/mlb__team_report_card.R`)

- New `lastTenGames` object per team: `{ label, columns, games[], record }`.
- Games come from the same hydrated MLB Stats API `/schedule` endpoint the 4-week trend uses — one request over a 30-day window, filtered to completed games (`codedGameState == "F"`), sorted chronologically per team and trimmed to the most recent 10.
- Each game carries `location` (`vs`/`@`), `opponent`, `opponentLabel`, `teamScore`, `opponentScore`, `differential`, `won`, `date`. `record` is `{ wins, losses, display }` over exactly those games.
- Degrades gracefully (empty list + `0-0`) if the request fails or a team has no games in the window.

## Web (`web/src/components/charts/MLBTeamReportCard.tsx`, `types/chart.ts`)

- New `LastTenGamesPanel` rendered at the top of the report-card masonry, styled to match the existing category panels (bordered card, centered header, table, footer record row).
- Differential is colored green/red by win/loss; the table scrolls horizontally within its panel if constrained, so the page body never overflows.
- Added `ReportCardLastTenGames` / `ReportCardGameLogGame` / `ReportCardGameLogRecord` types; wired onto `ReportCardTeam` as an optional field.

## KMP (`MLBTeamReportCardWorksheet.kt`, `VisualizationTypes.kt`)

- Matching `ReportCardLastTenGamesSection` at the top of the team worksheet, using the existing report-card row/header/stat text primitives for visual consistency.
- New **Last 10 Games** entry in the share FAB that renders a dedicated, width-adjusted share image (team name + subtitle, the game table, the record, and the `fbrk.app` footer). Width is measured from the team name / subtitle / source / table so the image never clips. The option is hidden when a team has no recent games.
- Added the serializable `ReportCardLastTenGames` / `ReportCardGameLogGame` / `ReportCardGameLogRecord` models; wired onto `ReportCardTeam` as a nullable field so existing cached JSON still parses.

## Verification

- Pipeline: R is not installed in the build environment, so the script wasn't executed against the live API; the fetch mirrors the existing `fetch_recent_trend_games` logic exactly (same endpoint, completed-game guard, helpers).
- Web / KMP: no local toolchain (no `node_modules`; a full KMP Gradle build would need the whole dependency graph over the proxy), so changes were verified by review. The new fields are optional/nullable on both `ReportCardTeam` types, so pre-existing report-card JSON continues to parse until the pipeline redeploys.

Worth a local `next build` / KMP compile and a run against a freshly generated JSON before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)